### PR TITLE
Set up the scaffolding for an inference algorithm

### DIFF
--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
-import Lexer
-import Lib ()
-import Parser
+import Inference (infer)
+import Lexer (alexScanTokens)
+import Parser (parse)
 import System.Environment
 
 main :: IO ()
@@ -11,6 +11,11 @@ main = do
   case args of
     [file] -> do
       program <- readFile file
-      let tokens = Lexer.alexScanTokens program
-      print (Parser.parse tokens)
+      let tokens = alexScanTokens program
+      let term   = parse tokens
+      let fterm  = infer term
+      putStrLn "Parsed term:"
+      putStrLn ("  " ++ show term)
+      putStrLn "Inferred term:"
+      putStrLn ("  " ++ show fterm)
     _ -> putStrLn "Usage:\n  implementation-exe <path>"

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -15,10 +15,11 @@ cabal-version:       >= 1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Lib
+  exposed-modules:     FSyntax
+                     , Inference
                      , Lexer
                      , Parser
-  other-modules:       Syntax
+                     , Syntax
   build-depends:       array
                      , base >= 4.7 && < 5
                      , containers
@@ -39,7 +40,9 @@ test-suite implementation-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             LibSpec.hs
-  other-modules:       LexerSpec
+  other-modules:       FSyntaxSpec
+                     , InferenceSpec
+                     , LexerSpec
                      , ParserSpec
                      , SyntaxSpec
   build-depends:       base

--- a/implementation/src/FSyntax.hs
+++ b/implementation/src/FSyntax.hs
@@ -1,0 +1,46 @@
+module FSyntax
+  ( FTerm(..)
+  , FType(..) ) where
+
+data FTerm -- Metavariable: e
+  = FEVar String
+  | FEAbs String FType FTerm
+  | FEApp FTerm FTerm
+  | FETAbs String FTerm
+  | FETApp FTerm FType
+  deriving Eq
+
+instance Show FTerm where
+  show (FEVar x) = x
+  show (FEAbs x t e) = "\\" ++ x ++ " : " ++ show t ++ " . " ++ show e
+  show (FEApp (FEAbs x t e1) (FEApp e2 e3)) =
+    "(" ++ show (FEAbs x t e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp (FEAbs x t1 e1) (FETApp e2 t2)) =
+    "(" ++ show (FEAbs x t1 e1) ++ ") (" ++ show (FETApp e2 t2) ++ ")"
+  show (FEApp (FEAbs x t e1) e2) =
+    "(" ++ show (FEAbs x t e1) ++ ") " ++ show e2
+  show (FEApp (FETAbs x e1) (FEApp e2 e3)) =
+    "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp (FETAbs x e1) (FETApp e2 t)) =
+    "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FETApp e2 t) ++ ")"
+  show (FEApp (FETAbs x e1) e2) = "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
+  show (FEApp e1 (FEApp e2 e3)) = show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp e1 (FETApp e2 t)) = show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
+  show (FEApp e1 e2) = show e1 ++ " " ++ show e2
+  show (FETAbs x e) = "\\" ++ x ++ " . " ++ show e
+  show (FETApp (FEAbs x t1 e) t2) =
+    "(" ++ show (FEAbs x t1 e) ++ ") " ++ show t2
+  show (FETApp (FETAbs x e) t) = "(" ++ show (FETAbs x e) ++ ") " ++ show t
+  show (FETApp e t) = show e ++ " " ++ show t
+
+data FType -- Metavariable: t
+  = FTVar String
+  | FTArrow FType FType
+  | FTForAll String FType
+  deriving Eq
+
+instance Show FType where
+  show (FTVar x) = x
+  show (FTArrow (FTVar x) t) = x ++ " -> " ++ show t
+  show (FTArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
+  show (FTForAll x t) = "forall " ++ x ++ " . " ++ show t

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,0 +1,8 @@
+module Inference
+  ( infer ) where
+
+import FSyntax (FTerm(..))
+import Syntax (Term(..))
+
+infer :: Term -> FTerm
+infer _ = FEVar "x"

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,9 +1,0 @@
-module Lib
-  ( Context(..)
-  , Term(..)
-  , Type(..) ) where
-
-import Syntax
-  ( Context(..)
-  , Term(..)
-  , Type(..) )

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -3,7 +3,7 @@
 module Parser (parse) where
 
 import Lexer (Token(..))
-import Lib (Term(..), Type(..))
+import Syntax (Term(..), Type(..))
 
 }
 

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -1,27 +1,35 @@
 module Syntax
-  ( Context(..)
-  , Term(..)
+  ( Term(..)
   , Type(..) ) where
-
--- Data types
 
 data Term -- Metavariable: e
   = EVar String
   | EAbs String Term
   | EApp Term Term
-  | ETAbs String Term
-  | ETApp Term Type
   | EAnno Term Type
-  deriving (Eq, Show)
+  deriving Eq
+
+instance Show Term where
+  show (EVar x) = x
+  show (EAbs x e) = "\\" ++ x ++ " . " ++ show e
+  show (EApp (EAbs x e1) (EApp e2 e3)) =
+    "(" ++ show (EAbs x e1) ++ ") (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp (EAbs x e1) e2) = "(" ++ show (EAbs x e1) ++ ") " ++ show e2
+  show (EApp (EAnno e1 t) (EApp e2 e3)) =
+    "(" ++ show (EAnno e1 t) ++ ") (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp (EAnno e1 t) e2) = "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
+  show (EApp e1 (EApp e2 e3)) = show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp e1 e2) = show e1 ++ " " ++ show e2
+  show (EAnno e t) = show e ++ " : " ++ show t
 
 data Type -- Metavariable: t
   = TVar String
   | TArrow Type Type
   | TForAll String Type
-  deriving (Eq, Show)
+  deriving Eq
 
-data Context -- Metavariable: c
-  = CEmpty
-  | CTExtend Context String Type
-  | CKExtend Context String
-  deriving (Eq, Show)
+instance Show Type where
+  show (TVar x) = x
+  show (TArrow (TVar x) t) = x ++ " -> " ++ show t
+  show (TArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
+  show (TForAll x t) = "forall " ++ x ++ " . " ++ show t

--- a/implementation/test/FSyntaxSpec.hs
+++ b/implementation/test/FSyntaxSpec.hs
@@ -1,0 +1,8 @@
+module FSyntaxSpec (fSyntaxSpec) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+-- The QuickCheck specs
+
+fSyntaxSpec :: Spec
+fSyntaxSpec = describe "fSyntax" $ it "should be correct" pending

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -1,0 +1,8 @@
+module InferenceSpec (inferenceSpec) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+-- The QuickCheck specs
+
+inferenceSpec :: Spec
+inferenceSpec = describe "inference" $ it "should be correct" pending

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -1,12 +1,14 @@
 import LexerSpec (lexerSpec)
 import ParserSpec (parserSpec)
 import SyntaxSpec (syntaxSpec)
+import FSyntaxSpec (fSyntaxSpec)
 import Test.Hspec (hspec)
 
 -- The QuickCheck specs
 
 main :: IO ()
 main = hspec $ do
+  fSyntaxSpec
   lexerSpec
   parserSpec
   syntaxSpec

--- a/paper/calculus.tex
+++ b/paper/calculus.tex
@@ -392,6 +392,6 @@
         \DisplayProof
       \end{center}
 
-      \caption{Translation into System F}
+      \caption{Elaboration into System F}
       \label{fig:semantics}
     \end{figure}


### PR DESCRIPTION
Set up the scaffolding for an inference algorithm. I also created a much better `show` instance for terms/types than the default one. Previously:

```haskell
EAnno
  (EAbs "f" (EAbs "g" (EAbs "x" (
    EApp (EApp (EVar "f") (EVar "g")) (EVar "x")
  ))))
  (TForAll "a" (TForAll "b" (TForAll "c" (
    TArrow (TVar "a") (TArrow (TVar "b") (TVar "c"))
  ))))
```

Now:

```haskell
\f . \g . \x . f g x : forall a . forall b . forall c . a -> b -> c
```

I would use `λ`, `Λ`, and `∀`, but apparently Brittany doesn't support Unicode.

@esdrw 