### PR TITLE
Improve the pretty printer

### DIFF
--- a/implementation/src/FSyntax.hs
+++ b/implementation/src/FSyntax.hs
@@ -10,9 +10,33 @@ data FTerm -- Metavariable: e
   | FETApp FTerm FType
   deriving Eq
 
+data FType -- Metavariable: t
+  = FTVar String
+  | FTArrow FType FType
+  | FTForAll String FType
+  deriving Eq
+
+collectAbs :: FTerm -> ([String], FTerm)
+collectAbs (FEVar x) = ([], FEVar x)
+collectAbs (FEAbs x t e1) =
+  let (xs, e2) = collectAbs e1
+  in  (("(" ++ x ++ " : " ++ show t ++ ")") : xs, e2)
+collectAbs (FEApp e1 e2) = ([], FEApp e1 e2)
+collectAbs (FETAbs x e1) =
+  let (xs, e2) = collectAbs e1 in (("(" ++ x ++ " : *)") : xs, e2)
+collectAbs (FETApp e t) = ([], FETApp e t)
+
+collectForAll :: FType -> ([String], FType)
+collectForAll (FTVar x      ) = ([], FTVar x)
+collectForAll (FTArrow t1 t2) = ([], FTArrow t1 t2)
+collectForAll (FTForAll x t1) =
+  let (xs, t2) = collectForAll t1 in (x : xs, t2)
+
 instance Show FTerm where
   show (FEVar x) = x
-  show (FEAbs x t e) = "\\" ++ x ++ " : " ++ show t ++ " . " ++ show e
+  show (FEAbs x t e1) =
+    let (xs, e2) = collectAbs (FEAbs x t e1)
+    in  "\\" ++ unwords xs ++ " . " ++ show e2
   show (FEApp (FEAbs x t e1) (FEApp e2 e3)) =
     "(" ++ show (FEAbs x t e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
   show (FEApp (FEAbs x t1 e1) (FETApp e2 t2)) =
@@ -23,24 +47,26 @@ instance Show FTerm where
     "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
   show (FEApp (FETAbs x e1) (FETApp e2 t)) =
     "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FETApp e2 t) ++ ")"
-  show (FEApp (FETAbs x e1) e2) = "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
-  show (FEApp e1 (FEApp e2 e3)) = show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
-  show (FEApp e1 (FETApp e2 t)) = show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
+  show (FEApp (FETAbs x e1) e2) =
+    "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
+  show (FEApp e1 (FEApp e2 e3)) =
+    show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp e1 (FETApp e2 t)) =
+    show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
   show (FEApp e1 e2) = show e1 ++ " " ++ show e2
-  show (FETAbs x e) = "\\" ++ x ++ " . " ++ show e
+  show (FETAbs x e1) =
+    let (xs, e2) = collectAbs (FETAbs x e1)
+    in  "\\" ++ unwords xs ++ " . " ++ show e2
   show (FETApp (FEAbs x t1 e) t2) =
     "(" ++ show (FEAbs x t1 e) ++ ") " ++ show t2
-  show (FETApp (FETAbs x e) t) = "(" ++ show (FETAbs x e) ++ ") " ++ show t
+  show (FETApp (FETAbs x e) t) =
+    "(" ++ show (FETAbs x e) ++ ") " ++ show t
   show (FETApp e t) = show e ++ " " ++ show t
-
-data FType -- Metavariable: t
-  = FTVar String
-  | FTArrow FType FType
-  | FTForAll String FType
-  deriving Eq
 
 instance Show FType where
   show (FTVar x) = x
   show (FTArrow (FTVar x) t) = x ++ " -> " ++ show t
   show (FTArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
-  show (FTForAll x t) = "forall " ++ x ++ " . " ++ show t
+  show (FTForAll x t1) =
+    let (xs, t2) = collectForAll (FTForAll x t1)
+    in  "forall " ++ unwords xs ++ " . " ++ show t2

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,8 +1,11 @@
 module Inference
   ( infer ) where
 
-import FSyntax (FTerm(..))
+import FSyntax (FTerm(..), FType(..))
 import Syntax (Term(..))
 
 infer :: Term -> FTerm
-infer _ = FEVar "x"
+infer _ = FEAbs
+  "x"
+  (FTForAll "a" $ FTForAll "b" (FTArrow (FTVar "a") (FTVar "b")))
+  (FEVar "x")

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -9,27 +9,45 @@ data Term -- Metavariable: e
   | EAnno Term Type
   deriving Eq
 
-instance Show Term where
-  show (EVar x) = x
-  show (EAbs x e) = "\\" ++ x ++ " . " ++ show e
-  show (EApp (EAbs x e1) (EApp e2 e3)) =
-    "(" ++ show (EAbs x e1) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAbs x e1) e2) = "(" ++ show (EAbs x e1) ++ ") " ++ show e2
-  show (EApp (EAnno e1 t) (EApp e2 e3)) =
-    "(" ++ show (EAnno e1 t) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAnno e1 t) e2) = "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
-  show (EApp e1 (EApp e2 e3)) = show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp e1 e2) = show e1 ++ " " ++ show e2
-  show (EAnno e t) = show e ++ " : " ++ show t
-
 data Type -- Metavariable: t
   = TVar String
   | TArrow Type Type
   | TForAll String Type
   deriving Eq
 
+collectAbs :: Term -> ([String], Term)
+collectAbs (EVar x     ) = ([], EVar x)
+collectAbs (EAbs  x  e1) = let (xs, e2) = collectAbs e1 in (x : xs, e2)
+collectAbs (EApp  e1 e2) = ([], EApp e1 e2)
+collectAbs (EAnno e  t ) = ([], EAnno e t)
+
+collectForAll :: Type -> ([String], Type)
+collectForAll (TVar x       ) = ([], TVar x)
+collectForAll (TArrow  t1 t2) = ([], TArrow t1 t2)
+collectForAll (TForAll x  t1) = let (xs, t2) = collectForAll t1 in (x : xs, t2)
+
+instance Show Term where
+  show (EVar x) = x
+  show (EAbs x e1) =
+    let (xs, e2) = collectAbs (EAbs x e1)
+    in  "\\" ++ unwords xs ++ " . " ++ show e2
+  show (EApp (EAbs x e1) (EApp e2 e3)) =
+    "(" ++ show (EAbs x e1) ++ ") (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp (EAbs x e1) e2) =
+    "(" ++ show (EAbs x e1) ++ ") " ++ show e2
+  show (EApp (EAnno e1 t) (EApp e2 e3)) =
+    "(" ++ show (EAnno e1 t) ++ ") (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp (EAnno e1 t) e2) =
+    "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
+  show (EApp e1 (EApp e2 e3)) =
+    show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp  e1 e2) = show e1 ++ " " ++ show e2
+  show (EAnno e  t ) = show e ++ " : " ++ show t
+
 instance Show Type where
   show (TVar x) = x
   show (TArrow (TVar x) t) = x ++ " -> " ++ show t
   show (TArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
-  show (TForAll x t) = "forall " ++ x ++ " . " ++ show t
+  show (TForAll x t1) =
+    let (xs, t2) = collectForAll (TForAll x t1)
+    in  "forall " ++ unwords xs ++ " . " ++ show t2


### PR DESCRIPTION
Improve the pretty printer by collecting variables in nested abstractions / foralls.

Before:

```haskell
\f . \g . \x . f g x : forall a . forall b . forall c . a -> b -> c
```

After:

```haskell
\f g x . f g x : forall a b c . a -> b -> c
```

@esdrw 