### PR TITLE
Refactor the pretty-printers

### DIFF
--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -4,6 +4,10 @@ module Inference
 import Syntax (FTerm(..), Term(..), Type(..))
 
 infer :: Term -> FTerm
-infer _ = FEAbs "x"
-                (TForAll "a" $ TForAll "b" (TArrow (TVar "a") (TVar "b")))
-                (FEVar "x")
+infer _ = FEAbs
+  "x"
+  (TVar "a")
+  ( FEAbs "y"
+          (TVar "b")
+          (FEAbs "z" (TVar "b") (FEAbs "w" (TVar "a") (FEVar "f")))
+  )


### PR DESCRIPTION
Refactor the pretty-printers. I got to (had to) use functional dependencies. :) I also tried implementing this with type families (associated types), but it was uglier. So fundeps it is!

The only observable change: I made the pretty printer group related arguments. Before:

```haskell
\(x : a) (y : b) (z : b) (w : a) . f
```

After:

```haskell
\(x : a) (y z : b) (w : a) . f
```

@esdrw 