### PR TITLE
Switch from brittany to hindent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint-implementation:
 	    -name '*.hs' \
 	  \) -print \
 	); do \
-	  brittany "$$file" > "$$file.tmp"; \
+	  cat "$$file" | hindent --line-length 79 > "$$file.tmp"; \
 	  (cmp "$$file.tmp" "$$file" && rm "$$file.tmp") || \
 	    (rm "$$file.tmp" && false) || exit 1; \
 	done
@@ -149,7 +149,9 @@ format-implementation:
 	    -name '*.hs' \
 	  \) -print \
 	); do \
-	  brittany --write-mode=inplace "$$file"; \
+	  cat "$$file" | hindent --line-length 79 > "$$file.tmp"; \
+	  (cmp --quiet "$$file.tmp" "$$file" && rm "$$file.tmp") || \
+	    mv "$$file.tmp" "$$file"; \
 	done
 
 clean-implementation:

--- a/implementation/Setup.hs
+++ b/implementation/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import Data.Char (isSpace)
 import Inference (infer)
@@ -8,17 +10,18 @@ import System.Environment (getArgs)
 import System.IO (hFlush, stdout)
 
 runProgram :: String -> IO ()
-runProgram program = if all isSpace program
-  then return ()
-  else do
-    let result = do
-          tokens <- scan program
-          term   <- parse tokens
-          let fterm = infer term
-          return fterm
-    case result of
-      Left  s     -> putStrLn ("  " ++ s)
-      Right fterm -> putStrLn ("  " ++ show fterm)
+runProgram program =
+  if all isSpace program
+    then return ()
+    else do
+      let result = do
+            tokens <- scan program
+            term <- parse tokens
+            let fterm = infer term
+            return fterm
+      case result of
+        Left s -> putStrLn ("  " ++ s)
+        Right fterm -> putStrLn ("  " ++ show fterm)
 
 main :: IO ()
 main = do
@@ -34,5 +37,5 @@ main = do
             program <- getLine
             runProgram program
             repl
-      in  repl
+      in repl
     _ -> putStrLn "Usage:\n  implementation-exe\n  implementation-exe <path>"

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,13 +1,15 @@
 module Inference
-  ( infer ) where
+  ( infer
+  ) where
 
 import Syntax (FTerm(..), Term(..), Type(..))
 
 infer :: Term -> FTerm
-infer _ = FEAbs
-  "x"
-  (TVar "a")
-  ( FEAbs "y"
-          (TVar "b")
-          (FEAbs "z" (TVar "b") (FEAbs "w" (TVar "a") (FEVar "f")))
-  )
+infer _ =
+  FEAbs
+    "x"
+    (TVar "a")
+    (FEAbs
+       "y"
+       (TVar "b")
+       (FEAbs "z" (TVar "b") (FEAbs "w" (TVar "a") (FEVar "f"))))

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -5,55 +5,69 @@
 module Syntax
   ( FTerm(..)
   , Term(..)
-  , Type(..) ) where
+  , Type(..)
+  ) where
 
 import Data.Function (on)
 import Data.List (groupBy)
 
 data Term -- Metavariable: e
   = EVar String
-  | EAbs String Term
-  | EApp Term Term
-  | EAnno Term Type
-  deriving Eq
+  | EAbs String
+         Term
+  | EApp Term
+         Term
+  | EAnno Term
+          Type
+  deriving (Eq)
 
 data FTerm -- Metavariable: e
   = FEVar String
-  | FEAbs String Type FTerm
-  | FEApp FTerm FTerm
-  | FETAbs String FTerm
-  | FETApp FTerm Type
-  deriving Eq
+  | FEAbs String
+          Type
+          FTerm
+  | FEApp FTerm
+          FTerm
+  | FETAbs String
+           FTerm
+  | FETApp FTerm
+           Type
+  deriving (Eq)
 
 data Type -- Metavariable: t
   = TVar String
-  | TArrow Type Type
-  | TForAll String Type
-  deriving Eq
+  | TArrow Type
+           Type
+  | TForAll String
+            Type
+  deriving (Eq)
 
 class CollectParams a b | a -> b where
   collectParams :: a -> ([b], a)
 
 instance CollectParams Term String where
-  collectParams (EVar x     ) = ([], EVar x)
-  collectParams (EAbs  x  e1) = let (xs, e2) = collectParams e1 in (x : xs, e2)
-  collectParams (EApp  e1 e2) = ([], EApp e1 e2)
-  collectParams (EAnno e  t ) = ([], EAnno e t)
+  collectParams (EVar x) = ([], EVar x)
+  collectParams (EAbs x e1) =
+    let (xs, e2) = collectParams e1
+    in (x : xs, e2)
+  collectParams (EApp e1 e2) = ([], EApp e1 e2)
+  collectParams (EAnno e t) = ([], EAnno e t)
 
 instance CollectParams FTerm (String, String) where
   collectParams (FEVar x) = ([], FEVar x)
   collectParams (FEAbs x t e1) =
     let (xs, e2) = collectParams e1
-    in  ((x, show t) : xs, e2)
+    in ((x, show t) : xs, e2)
   collectParams (FEApp e1 e2) = ([], FEApp e1 e2)
   collectParams (FETAbs x e1) =
-    let (xs, e2) = collectParams e1 in ((x, "*") : xs, e2)
+    let (xs, e2) = collectParams e1
+    in ((x, "*") : xs, e2)
   collectParams (FETApp e t) = ([], FETApp e t)
 
 instance CollectParams Type String where
-  collectParams (TVar x       ) = ([], TVar x)
-  collectParams (TArrow  t1 t2) = ([], TArrow t1 t2)
-  collectParams (TForAll x  t1) =
+  collectParams (TVar x) = ([], TVar x)
+  collectParams (TArrow t1 t2) = ([], TArrow t1 t2)
+  collectParams (TForAll x t1) =
     let (xs, t2) = collectParams t1
     in (x : xs, t2)
 
@@ -64,35 +78,33 @@ instance PresentParams String where
   presentParams = unwords
 
 instance PresentParams (String, String) where
-  presentParams xs = unwords $ do
-    group <- groupBy (on (==) snd) xs
-    let ys = fst <$> group
-    let t = snd (head group)
-    return $ "(" ++ unwords ys ++ " : " ++ t ++ ")"
+  presentParams xs =
+    unwords $ do
+      group <- groupBy (on (==) snd) xs
+      let ys = fst <$> group
+      let t = snd (head group)
+      return $ "(" ++ unwords ys ++ " : " ++ t ++ ")"
 
 instance Show Term where
   show (EVar x) = x
   show (EAbs x e1) =
     let (xs, e2) = collectParams (EAbs x e1)
-    in  "\\" ++ presentParams xs ++ " . " ++ show e2
+    in "λ" ++ presentParams xs ++ " . " ++ show e2
   show (EApp (EAbs x e1) (EApp e2 e3)) =
     "(" ++ show (EAbs x e1) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAbs x e1) e2) =
-    "(" ++ show (EAbs x e1) ++ ") " ++ show e2
+  show (EApp (EAbs x e1) e2) = "(" ++ show (EAbs x e1) ++ ") " ++ show e2
   show (EApp (EAnno e1 t) (EApp e2 e3)) =
     "(" ++ show (EAnno e1 t) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAnno e1 t) e2) =
-    "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
-  show (EApp e1 (EApp e2 e3)) =
-    show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp  e1 e2) = show e1 ++ " " ++ show e2
-  show (EAnno e  t ) = show e ++ " : " ++ show t
+  show (EApp (EAnno e1 t) e2) = "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
+  show (EApp e1 (EApp e2 e3)) = show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
+  show (EApp e1 e2) = show e1 ++ " " ++ show e2
+  show (EAnno e t) = show e ++ " : " ++ show t
 
 instance Show FTerm where
   show (FEVar x) = x
   show (FEAbs x t e1) =
     let (xs, e2) = collectParams (FEAbs x t e1)
-    in  "\\" ++ presentParams xs ++ " . " ++ show e2
+    in "λ" ++ presentParams xs ++ " . " ++ show e2
   show (FEApp (FEAbs x t e1) (FEApp e2 e3)) =
     "(" ++ show (FEAbs x t e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
   show (FEApp (FEAbs x t1 e1) (FETApp e2 t2)) =
@@ -103,20 +115,16 @@ instance Show FTerm where
     "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
   show (FEApp (FETAbs x e1) (FETApp e2 t)) =
     "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FETApp e2 t) ++ ")"
-  show (FEApp (FETAbs x e1) e2) =
-    "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
-  show (FEApp e1 (FEApp e2 e3)) =
-    show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
-  show (FEApp e1 (FETApp e2 t)) =
-    show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
+  show (FEApp (FETAbs x e1) e2) = "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
+  show (FEApp e1 (FEApp e2 e3)) = show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp e1 (FETApp e2 t)) = show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
   show (FEApp e1 e2) = show e1 ++ " " ++ show e2
   show (FETAbs x e1) =
     let (xs, e2) = collectParams (FETAbs x e1)
-    in  "\\" ++ presentParams xs ++ " . " ++ show e2
+    in "λ" ++ presentParams xs ++ " . " ++ show e2
   show (FETApp (FEAbs x t1 e) t2) =
     "(" ++ show (FEAbs x t1 e) ++ ") " ++ show t2
-  show (FETApp (FETAbs x e) t) =
-    "(" ++ show (FETAbs x e) ++ ") " ++ show t
+  show (FETApp (FETAbs x e) t) = "(" ++ show (FETAbs x e) ++ ") " ++ show t
   show (FETApp e t) = show e ++ " " ++ show t
 
 instance Show Type where
@@ -125,4 +133,4 @@ instance Show Type where
   show (TArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
   show (TForAll x t1) =
     let (xs, t2) = collectParams (TForAll x t1)
-    in  "forall " ++ presentParams xs ++ " . " ++ show t2
+    in "∀" ++ presentParams xs ++ " . " ++ show t2

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -1,8 +1,9 @@
-module InferenceSpec (inferenceSpec) where
+module InferenceSpec
+  ( inferenceSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 inferenceSpec :: Spec
 inferenceSpec = describe "inference" $ it "should be correct" pending

--- a/implementation/test/LexerSpec.hs
+++ b/implementation/test/LexerSpec.hs
@@ -1,8 +1,9 @@
-module LexerSpec (lexerSpec) where
+module LexerSpec
+  ( lexerSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 lexerSpec :: Spec
 lexerSpec = describe "alexScanTokens" $ it "should be correct" pending

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -4,9 +4,9 @@ import SyntaxSpec (syntaxSpec)
 import Test.Hspec (hspec)
 
 -- The QuickCheck specs
-
 main :: IO ()
-main = hspec $ do
-  lexerSpec
-  parserSpec
-  syntaxSpec
+main =
+  hspec $ do
+    lexerSpec
+    parserSpec
+    syntaxSpec

--- a/implementation/test/ParserSpec.hs
+++ b/implementation/test/ParserSpec.hs
@@ -1,8 +1,9 @@
-module ParserSpec (parserSpec) where
+module ParserSpec
+  ( parserSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 parserSpec :: Spec
 parserSpec = describe "parse" $ it "should be correct" pending

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -1,8 +1,9 @@
-module SyntaxSpec (syntaxSpec) where
+module SyntaxSpec
+  ( syntaxSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 syntaxSpec :: Spec
 syntaxSpec = describe "syntax" $ it "should be correct" pending

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,22 +1,14 @@
 FROM debian:stretch
 
-# We install the `libtinfo-dev` package to work around a strange bug in Stack.
-# Without it, we get this error when running `stack install brittany` below:
-#   <command line>: can't load .so/.DLL for: libtinfo.so
-#   (libtinfo.so: cannot open shared object file: No such file or directory)
 RUN \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     'build-essential=12.3' \
-    'libtinfo-dev=6.0+*' \
     'python-pip=9.0.*' \
     'ruby=1:2.3.*' \
     'texlive-full=2016.*' && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /usr/share/doc
-
-# Without this, Ruby will assume that files are encoded as ASCII.
-RUN echo 'export LANG="C.UTF-8"' >> ~/.profile
 
 RUN \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
@@ -59,6 +51,9 @@ USER user:user
 
 WORKDIR /home/user
 
+# Without this, Ruby will assume files are encoded as ASCII.
+RUN echo 'export LANG="C.UTF-8"' >> ~/.profile
+
 # Stack installs executables in $HOME/.local/bin.
 RUN \
   mkdir -p "$HOME/.local/bin" && \
@@ -66,6 +61,4 @@ RUN \
 
 RUN stack setup --resolver lts-10.4
 
-# The `mkdir` command is needed to work around a bug in brittany. See
-# https://github.com/lspitzner/brittany/issues/115 for details.
-RUN mkdir "$HOME/.config" && stack install brittany hlint
+RUN stack install hindent hlint


### PR DESCRIPTION
Switch from `brittany` to `hindent` for formatting Haskell. I think `brittany` produces better-looking output in some cases, but `hindent` is more consistent. Furthermore, `hindent` supports Unicode (so we can use symbols like `λ` in strings). Switching to `hindent` also allows us to remove some hacks in the Dockerfile.

I also made a small improvement to the `Makefile` that ensures file timestamps are not touched when running `make format-implementation` unless there are actual changes to be made. So that means running `make format-implementaiton` will not invalidate the build cache unless any files were actually affected.

@esdrw 