### PR TITLE
Implement a simple type inference algorithm

### DIFF
--- a/.hindent.yaml
+++ b/.hindent.yaml
@@ -1,0 +1,3 @@
+indent-size: 2
+line-length: 79
+force-trailing-newline: true

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint-implementation:
 	    -name '*.hs' \
 	  \) -print \
 	); do \
-	  cat "$$file" | hindent --line-length 79 > "$$file.tmp"; \
+	  cat "$$file" | hindent > "$$file.tmp"; \
 	  (cmp "$$file.tmp" "$$file" && rm "$$file.tmp") || \
 	    (rm "$$file.tmp" && false) || exit 1; \
 	done
@@ -149,7 +149,7 @@ format-implementation:
 	    -name '*.hs' \
 	  \) -print \
 	); do \
-	  cat "$$file" | hindent --line-length 79 > "$$file.tmp"; \
+	  cat "$$file" | hindent > "$$file.tmp"; \
 	  (cmp --quiet "$$file.tmp" "$$file" && rm "$$file.tmp") || \
 	    mv "$$file.tmp" "$$file"; \
 	done

--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -3,7 +3,7 @@ module Main
   ) where
 
 import Data.Char (isSpace)
-import Inference (infer)
+import Inference (typeCheck)
 import Lexer (scan)
 import Parser (parse)
 import System.Environment (getArgs)
@@ -17,11 +17,10 @@ runProgram program =
       let result = do
             tokens <- scan program
             term <- parse tokens
-            let fterm = infer term
-            return fterm
+            typeCheck term
       case result of
         Left s -> putStrLn ("  " ++ s)
-        Right fterm -> putStrLn ("  " ++ show fterm)
+        Right (e, t) -> putStrLn ("  " ++ show e ++ "\n  : " ++ show t)
 
 main :: IO ()
 main = do

--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -1,1 +1,1 @@
-\f g x . f g x : forall a b c . a -> b -> c
+\x . x : forall a . a -> a

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -19,10 +19,12 @@ library
                      , Lexer
                      , Parser
                      , Syntax
-  build-depends:       array
+  build-depends:       QuickCheck
+                     , array
                      , base >= 4.7 && < 5
+                     , bimap
                      , containers
-                     , QuickCheck
+                     , mtl
   default-language:    Haskell2010
   build-tools:         alex
                      , happy

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,15 +1,342 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 module Inference
-  ( infer
+  ( typeCheck
   ) where
 
-import Syntax (FTerm(..), Term(..), Type(..))
+import Control.Arrow (first, second)
+import Control.Monad (foldM, when)
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
+import Control.Monad.Reader (Reader, ask, local, runReader)
+import Control.Monad.State (StateT, get, put, runStateT)
+import qualified Data.Bimap as Bimap
+import Data.Bimap (Bimap)
+import Data.List (foldl')
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromJust, fromMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Syntax
+  ( CollectParams
+  , EVar(..)
+  , FTerm(..)
+  , ITerm(..)
+  , TVar(..)
+  , Type(..)
+  , collectParams
+  , presentParams
+  , substEVarInTerm
+  , substVarInType
+  , tFreeVars
+  )
 
-infer :: Term -> FTerm
-infer _ =
-  FEAbs
-    "x"
-    (TVar "a")
-    (FEAbs
-       "y"
-       (TVar "b")
-       (FEAbs "z" (TVar "b") (FEAbs "w" (TVar "a") (FEVar "f"))))
+-- Unification variables are holes in a type.
+newtype Unifier = ToUnifier
+  { fromUnifier :: String
+  } deriving (Eq, Ord)
+
+instance Show Unifier where
+  show = fromUnifier
+
+-- A PartialType is like a Type but it may contain unification variables.
+data PartialType
+  = PTUnifier Unifier
+  | PTVar TVar
+  | PTArrow PartialType
+            PartialType
+  | PTForAll TVar
+             PartialType
+
+instance CollectParams PartialType String where
+  collectParams (PTUnifier u) = ([], PTUnifier u)
+  collectParams (PTVar a) = ([], PTVar a)
+  collectParams (PTArrow t1 t2) = ([], PTArrow t1 t2)
+  collectParams (PTForAll a t1) =
+    let (as, t2) = collectParams t1
+    in (show a : as, t2)
+
+instance Eq PartialType where
+  PTUnifier u1 == PTUnifier u2 = u1 == u2
+  PTVar a1 == PTVar a2 = a1 == a2
+  PTArrow t1 t2 == PTArrow t3 t4 = t1 == t3 && t2 == t4
+  PTForAll a1 t1 == PTForAll a2 t2 =
+    t1 == substVarInPartialType a2 (PTVar a1) t2 &&
+    t2 == substVarInPartialType a1 (PTVar a2) t1
+  _ == _ = False
+
+instance Show PartialType where
+  show (PTUnifier u) = fromUnifier u ++ "?"
+  show (PTVar a) = show a
+  show (PTArrow (PTVar a) t) = show a ++ " -> " ++ show t
+  show (PTArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
+  show (PTForAll a t1) =
+    let (as, t2) = collectParams (PTForAll a t1)
+    in "∀" ++ presentParams as ++ " . " ++ show t2
+
+-- Substitution
+substVarInPartialType :: TVar -> PartialType -> PartialType -> PartialType
+substVarInPartialType _ _ (PTUnifier u) = PTUnifier u
+substVarInPartialType a1 t (PTVar a2) =
+  if a1 == a2
+    then t
+    else PTVar a2
+substVarInPartialType a t1 (PTArrow t2 t3) =
+  PTArrow (substVarInPartialType a t1 t2) (substVarInPartialType a t1 t3)
+substVarInPartialType a1 t1 (PTForAll a2 t2) =
+  PTForAll a2 $
+  if a1 == a2
+    then t2
+    else substVarInPartialType a1 t1 t2
+
+-- Contexts can hold term variables and type variables.
+type Context = (Map EVar Type, Set TVar)
+
+-- The TypeCheck monad provides:
+-- 1. The ability to read the context (via Reader).
+-- 2. The ability to generate fresh variables (via StateT).
+-- 3. The ability to throw errors (via ExceptT).
+type TypeCheck = ExceptT String (StateT Int (Reader Context))
+
+-- Generate a fresh term variable.
+freshEVar :: String -> TypeCheck EVar
+freshEVar x = do
+  context <- ask
+  case Map.lookup (ToEVar x) (fst context) of
+    Just _ -> do
+      i <- get
+      put (i + 1)
+      return $ ToEVar ("@" ++ show i)
+    Nothing -> return $ ToEVar x
+
+-- Generate a fresh type variable.
+freshTVar :: String -> TypeCheck TVar
+freshTVar a = do
+  context <- ask
+  if Set.member (ToTVar a) (snd context)
+    then do
+      i <- get
+      put (i + 1)
+      return $ ToTVar ("@" ++ show i)
+    else return $ ToTVar a
+
+-- Generate a fresh unifier.
+freshUnifier :: String -> TypeCheck Unifier
+freshUnifier u = return $ ToUnifier (u ++ "?")
+
+-- Look up a term variable in the context.
+eLookupVar :: EVar -> TypeCheck Type
+eLookupVar x = do
+  context <- ask
+  case Map.lookup x (fst context) of
+    Just t -> return t
+    Nothing -> throwError $ "Undefined term variable: " ++ show x
+
+-- Check that a type variable is in the context.
+tLookupVar :: TVar -> TypeCheck ()
+tLookupVar a = do
+  context <- ask
+  if Set.member a (snd context)
+    then return ()
+    else throwError $ "Undefined type variable: " ++ show a
+
+-- Convert a Type to a PartialType.
+makePartial :: Type -> PartialType
+makePartial (TVar a) = PTVar a
+makePartial (TArrow t1 t2) = PTArrow (makePartial t1) (makePartial t2)
+makePartial (TForAll a t) = PTForAll a (makePartial t)
+
+-- Convert a PartialType to a Type. An error will be thrown if the type
+-- contains any unifiers.
+makeTotal :: PartialType -> TypeCheck Type
+makeTotal (PTUnifier u) = throwError $ "Unexpected unifier: " ++ show u
+makeTotal (PTVar a) = return $ TVar a
+makeTotal (PTArrow t1 t2) = do
+  t3 <- makeTotal t1
+  t4 <- makeTotal t2
+  return $ TArrow t3 t4
+makeTotal (PTForAll a t1) = do
+  t2 <- makeTotal t1
+  return $ TForAll a t2
+
+-- Instantiate outer quantifiers with fresh type variables. Returns the type
+-- and a list of the fresh variables.
+elimQuantifiers :: Type -> TypeCheck (Type, [TVar])
+elimQuantifiers (TVar a) = return (TVar a, [])
+elimQuantifiers (TArrow t1 t2) = return (TArrow t1 t2, [])
+elimQuantifiers (TForAll a1 t1) = do
+  a2 <- freshTVar (fromTVar a1)
+  (t2, as) <- elimQuantifiers (substVarInType a1 (TVar a2) t1)
+  return (t2, a2 : as)
+
+-- Helpers to compute free variables.
+ptFreeVars :: PartialType -> [TVar]
+ptFreeVars (PTUnifier _) = []
+ptFreeVars (PTVar a) = [a]
+ptFreeVars (PTArrow t1 t2) = ptFreeVars t1 ++ ptFreeVars t2
+ptFreeVars (PTForAll a t) = filter (/= a) (ptFreeVars t)
+
+-- Check that the free variables of a type are bound in the context.
+ensureTypeWellFormed :: Type -> TypeCheck ()
+ensureTypeWellFormed t = mapM_ tLookupVar (tFreeVars t)
+
+-- Given a list of type variables, generate a fresh unifier for each.
+freshUnifiers :: [TVar] -> TypeCheck (Bimap TVar Unifier)
+freshUnifiers =
+  foldM
+    (\memo a -> do
+       u <- freshUnifier (fromTVar a)
+       return $ Bimap.insert a u memo)
+    Bimap.empty
+
+-- Find an instantiation that turns the second PartialType into the first.
+unify :: PartialType -> PartialType -> TypeCheck (Map Unifier Type)
+unify t1 (PTUnifier u) = do
+  t2 <- makeTotal t1
+  return $ Map.singleton u t2
+unify (PTVar a1) (PTVar a2) =
+  if a1 == a2
+    then return Map.empty
+    else throwError $ "Unable to unify " ++ show a1 ++ " with " ++ show a2
+unify (PTArrow t1 t2) (PTArrow t3 t4) = do
+  is1 <- unify t1 t3
+  is2 <- unify t2 t4
+  if all
+       (\u -> Map.lookup u is1 == Map.lookup u is2)
+       (Map.keys (Map.intersection is1 is2))
+    then return ()
+    else throwError $
+         "Unable to unify " ++
+         show (PTArrow t1 t2) ++ " with " ++ show (PTArrow t3 t4)
+  return $ Map.union is1 is2
+unify (PTForAll a1 t1) (PTForAll a2 t2) = do
+  when (a1 `elem` ptFreeVars (PTForAll a2 t2)) $
+    throwError $
+    "Unable to unify " ++
+    show (PTForAll a1 t1) ++ " with " ++ show (PTForAll a2 t2)
+  unify t1 (substVarInPartialType a2 (PTVar a1) t2)
+unify t1 t2 = throwError $ "Unable to unify " ++ show t1 ++ " with " ++ show t2
+
+-- Infer the type of a term.
+infer :: ITerm -> TypeCheck (FTerm, Type)
+infer (IEVar x) = do
+  t <- eLookupVar x
+  return (FEVar x, t)
+infer (IEApp e1 e2)
+  -- Infer the type of e1.
+ = do
+  (e3, t1) <- infer e1
+  -- Eliminate the quantifiers to get the argument and return type of the
+  -- function.
+  (t2, as) <- elimQuantifiers t1
+  (t3, t4) <-
+    case t2 of
+      TArrow t3 t4 -> return (t3, t4)
+      _ -> throwError $ "Not a function type: " ++ show t2
+  -- Replace variables from the eliminated quantifiers with fresh unifiers.
+  aToU <- freshUnifiers as
+  let t5 =
+        Map.foldrWithKey
+          substVarInPartialType
+          (makePartial t3)
+          (PTUnifier <$> Bimap.toMap aToU)
+  -- Check the argument.
+  (e4, uToT) <- check e2 t5
+  -- Use the unification results to instantiate the quantifiers.
+  let e6 =
+        foldl'
+          (\e5 a ->
+             FETApp e5 $
+             fromMaybe
+               (TVar a)
+               (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT))
+          e3
+          as
+  let t7 =
+        foldl'
+          (\t6 a ->
+             substVarInType
+               a
+               (fromMaybe
+                  (TVar a)
+                  (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT))
+               t6)
+          t4
+          as
+  -- Construct the application.
+  let e7 = FEApp e6 e4
+  -- Re-generalize the result.
+  return $ foldl' (\(e8, t6) a -> (FETAbs a e8, TForAll a t6)) (e7, t7) as
+infer (IEAnno e1 t) = do
+  ensureTypeWellFormed t
+  (e2, _) <- check e1 (makePartial t)
+  return (e2, t)
+infer t = throwError $ "Please annotate the type of: " ++ show t
+
+-- Check a term against a type and possibly instantiate unifiers in the type.
+check :: ITerm -> PartialType -> TypeCheck (FTerm, Map Unifier Type)
+check e1 (PTUnifier u) = do
+  (e2, t) <- infer e1
+  return (e2, Map.singleton u t)
+check e1 (PTForAll a1 t) = do
+  a2 <- freshTVar (fromTVar a1)
+  (e2, uToT) <-
+    local (second (Set.insert a2)) $
+    check e1 (substVarInPartialType a1 (PTVar a2) t)
+  return (FETAbs a2 e2, uToT)
+check (IEAbs x1 e1) (PTArrow t1 t2) = do
+  x2 <- freshEVar (fromEVar x1)
+  t3 <- makeTotal t1
+  (e2, uToT) <-
+    local (first (Map.insert x2 t3)) $
+    check (substEVarInTerm x1 (IEVar x2) e1) t2
+  return (FEAbs x2 t3 e2, uToT)
+check e1 t1
+  -- Infer the type of e1.
+ = do
+  (e2, t2) <- infer e1
+  -- Eliminate quantifiers in the resulting type so we can unify it with t1.
+  (t3, as) <- elimQuantifiers t2
+  -- Replace variables from the eliminated quantifiers with fresh unifiers.
+  aToU <- freshUnifiers as
+  let t4 =
+        Map.foldrWithKey
+          substVarInPartialType
+          (makePartial t3)
+          (PTUnifier <$> Bimap.toMap aToU)
+  -- Unify the result with t1.
+  uToT1 <- unify t1 t4
+  -- Use the unification results to instantiate the quantifiers.
+  let e4 =
+        foldl'
+          (\e3 a ->
+             FETApp e3 $
+             fromMaybe
+               (TVar $ ToTVar "unit")
+               (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT1))
+          e2
+          as
+  let t6 =
+        foldl'
+          (\t5 a ->
+             substVarInType
+               a
+               (fromMaybe
+                  (TVar $ ToTVar "unit")
+                  (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT1))
+               t5)
+          t3
+          as
+  -- Unify the original type against the inferred type with eliminated
+  -- quantifiers.
+  uToT2 <- unify (makePartial t6) t1
+  return (e4, uToT2)
+
+-- Given a term in the untyped language, return a term in the typed language
+-- together with its type.
+typeCheck :: ITerm -> Either String (FTerm, Type)
+typeCheck e =
+  let (result, _) =
+        runReader (runStateT (runExceptT (infer e)) 0) (Map.empty, Set.empty)
+  in result

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -3,7 +3,7 @@
 module Parser (parse) where
 
 import Lexer (Token(..))
-import Syntax (Term(..), Type(..))
+import Syntax (EVar(..), TVar(..), ITerm(..), Type(..))
 
 }
 
@@ -30,19 +30,19 @@ import Syntax (Term(..), Type(..))
 
 %%
 
-Term : x                        { EVar $1 }
-     | lambda VarList '.' Term  { foldr (\x e -> EAbs x e) $4 (reverse $2) }
-     | Term Term %prec APP      { EApp $1 $2 }
-     | Term ':' Type            { EAnno $1 $3 }
-     | '(' Term ')'             { $2 }
+ITerm : x                         { IEVar (ToEVar $1) }
+     | lambda VarList '.' ITerm   { foldr (\x e -> IEAbs (ToEVar x) e) $4 (reverse $2) }
+     | ITerm ITerm %prec APP      { IEApp $1 $2 }
+     | ITerm ':' Type             { IEAnno $1 $3 }
+     | '(' ITerm ')'              { $2 }
 
-Type : x                        { TVar $1 }
-     | Type '->' Type           { TArrow $1 $3 }
-     | forall VarList '.' Type  { foldr (\x t -> TForAll x t) $4 (reverse $2) }
-     | '(' Type ')'             { $2 }
+Type : x                          { TVar (ToTVar $1) }
+     | Type '->' Type             { TArrow $1 $3 }
+     | forall VarList '.' Type    { foldr (\x t -> TForAll (ToTVar x) t) $4 (reverse $2) }
+     | '(' Type ')'               { $2 }
 
-VarList : x                     { [$1] }
-        | VarList x             { $2 : $1 }
+VarList : x                       { [$1] }
+        | VarList x               { $2 : $1 }
 
 {
 

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -3,73 +3,225 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Syntax
-  ( FTerm(..)
-  , Term(..)
+  ( CollectParams
+  , PresentParams
+  , FTerm(..)
+  , ITerm(..)
+  , EVar(..)
+  , TVar(..)
   , Type(..)
+  , substEVarInTerm
+  , iFreeEVars
+  , iFreeTVars
+  , fFreeEVars
+  , fFreeTVars
+  , tFreeVars
+  , substTVarInTerm
+  , substEVarInFTerm
+  , substTVarInFTerm
+  , substVarInType
+  , collectParams
+  , presentParams
   ) where
 
 import Data.Function (on)
 import Data.List (groupBy)
 
-data Term -- Metavariable: e
-  = EVar String
-  | EAbs String
-         Term
-  | EApp Term
-         Term
-  | EAnno Term
-          Type
-  deriving (Eq)
+-- Data types
+newtype EVar = ToEVar
+  { fromEVar :: String
+  } deriving (Eq, Ord)
 
-data FTerm -- Metavariable: e
-  = FEVar String
-  | FEAbs String
+instance Show EVar where
+  show = fromEVar
+
+newtype TVar = ToTVar
+  { fromTVar :: String
+  } deriving (Eq, Ord)
+
+instance Show TVar where
+  show = fromTVar
+
+data ITerm
+  = IEVar EVar
+  | IEAbs EVar
+          ITerm
+  | IEApp ITerm
+          ITerm
+  | IEAnno ITerm
+           Type
+
+data FTerm
+  = FEVar EVar
+  | FEAbs EVar
           Type
           FTerm
   | FEApp FTerm
           FTerm
-  | FETAbs String
+  | FETAbs TVar
            FTerm
   | FETApp FTerm
            Type
-  deriving (Eq)
 
-data Type -- Metavariable: t
-  = TVar String
+data Type
+  = TVar TVar
   | TArrow Type
            Type
-  | TForAll String
+  | TForAll TVar
             Type
-  deriving (Eq)
 
+-- Free variables
+iFreeEVars :: ITerm -> [EVar]
+iFreeEVars (IEVar x) = [x]
+iFreeEVars (IEAbs x e) = filter (/= x) (iFreeEVars e)
+iFreeEVars (IEApp e1 e2) = iFreeEVars e1 ++ iFreeEVars e2
+iFreeEVars (IEAnno e _) = iFreeEVars e
+
+iFreeTVars :: ITerm -> [TVar]
+iFreeTVars (IEVar _) = []
+iFreeTVars (IEAbs _ e) = iFreeTVars e
+iFreeTVars (IEApp e1 e2) = iFreeTVars e1 ++ iFreeTVars e2
+iFreeTVars (IEAnno _ t) = tFreeVars t
+
+fFreeEVars :: FTerm -> [EVar]
+fFreeEVars (FEVar x) = [x]
+fFreeEVars (FEAbs x _ e) = filter (/= x) (fFreeEVars e)
+fFreeEVars (FEApp e1 e2) = fFreeEVars e1 ++ fFreeEVars e2
+fFreeEVars (FETAbs _ e) = fFreeEVars e
+fFreeEVars (FETApp e _) = fFreeEVars e
+
+fFreeTVars :: FTerm -> [TVar]
+fFreeTVars (FEVar _) = []
+fFreeTVars (FEAbs _ t e) = tFreeVars t ++ fFreeTVars e
+fFreeTVars (FEApp e1 e2) = fFreeTVars e1 ++ fFreeTVars e2
+fFreeTVars (FETAbs a e) = filter (/= a) (fFreeTVars e)
+fFreeTVars (FETApp e t) = fFreeTVars e ++ tFreeVars t
+
+tFreeVars :: Type -> [TVar]
+tFreeVars (TVar a) = [a]
+tFreeVars (TArrow t1 t2) = tFreeVars t1 ++ tFreeVars t2
+tFreeVars (TForAll a t) = filter (/= a) (tFreeVars t)
+
+-- Substitution
+substEVarInTerm :: EVar -> ITerm -> ITerm -> ITerm
+substEVarInTerm x1 e (IEVar x2) =
+  if x1 == x2
+    then e
+    else IEVar x2
+substEVarInTerm x1 e1 (IEAbs x2 e2) =
+  IEAbs x2 $
+  if x1 == x2
+    then e2
+    else substEVarInTerm x1 e1 e2
+substEVarInTerm x e1 (IEApp e2 e3) =
+  IEApp (substEVarInTerm x e1 e2) (substEVarInTerm x e1 e3)
+substEVarInTerm x e1 (IEAnno e2 t) = IEAnno (substEVarInTerm x e1 e2) t
+
+substTVarInTerm :: TVar -> Type -> ITerm -> ITerm
+substTVarInTerm _ _ (IEVar x) = IEVar x
+substTVarInTerm a t (IEAbs x e2) = IEAbs x (substTVarInTerm a t e2)
+substTVarInTerm a t (IEApp e1 e2) =
+  IEApp (substTVarInTerm a t e1) (substTVarInTerm a t e2)
+substTVarInTerm a t1 (IEAnno e t2) =
+  IEAnno (substTVarInTerm a t1 e) (substVarInType a t1 t2)
+
+substEVarInFTerm :: EVar -> FTerm -> FTerm -> FTerm
+substEVarInFTerm x1 e (FEVar x2) =
+  if x1 == x2
+    then e
+    else FEVar x2
+substEVarInFTerm x1 e1 (FEAbs x2 t e2) =
+  FEAbs x2 t $
+  if x1 == x2
+    then e2
+    else substEVarInFTerm x1 e1 e2
+substEVarInFTerm x e1 (FEApp e2 e3) =
+  FEApp (substEVarInFTerm x e1 e2) (substEVarInFTerm x e1 e3)
+substEVarInFTerm x e1 (FETAbs a e2) = FETAbs a (substEVarInFTerm x e1 e2)
+substEVarInFTerm x e1 (FETApp e2 t) = FETApp (substEVarInFTerm x e1 e2) t
+
+substTVarInFTerm :: TVar -> Type -> FTerm -> FTerm
+substTVarInFTerm _ _ (FEVar x) = FEVar x
+substTVarInFTerm a t1 (FEAbs x t2 e) =
+  FEAbs x (substVarInType a t1 t2) (substTVarInFTerm a t1 e)
+substTVarInFTerm a t (FEApp e1 e2) =
+  FEApp (substTVarInFTerm a t e1) (substTVarInFTerm a t e2)
+substTVarInFTerm a1 t (FETAbs a2 e) = FETAbs a2 (substTVarInFTerm a1 t e)
+substTVarInFTerm a t1 (FETApp e t2) =
+  FETApp (substTVarInFTerm a t2 e) (substVarInType a t1 t2)
+
+substVarInType :: TVar -> Type -> Type -> Type
+substVarInType a1 t (TVar a2) =
+  if a1 == a2
+    then t
+    else TVar a2
+substVarInType a t1 (TArrow t2 t3) =
+  TArrow (substVarInType a t1 t2) (substVarInType a t1 t3)
+substVarInType a1 t1 (TForAll a2 t2) =
+  TForAll a2 $
+  if a1 == a2
+    then t2
+    else substVarInType a1 t1 t2
+
+-- Equality
+instance Eq ITerm where
+  IEVar x1 == IEVar x2 = x1 == x2
+  IEAbs x1 e1 == IEAbs x2 e2 =
+    e1 == substEVarInTerm x2 (IEVar x1) e2 &&
+    e2 == substEVarInTerm x1 (IEVar x2) e1
+  IEApp e1 e2 == IEApp e3 e4 = e1 == e3 && e2 == e4
+  IEAnno e1 t1 == IEAnno e2 t2 = e1 == e2 && t1 == t2
+  _ == _ = False
+
+instance Eq FTerm where
+  FEVar x1 == FEVar x2 = x1 == x2
+  FEAbs x1 t1 e1 == FEAbs x2 t2 e2 =
+    e1 == substEVarInFTerm x2 (FEVar x1) e2 &&
+    e2 == substEVarInFTerm x1 (FEVar x2) e1 && t1 == t2
+  FEApp e1 e2 == FEApp e3 e4 = e1 == e3 && e2 == e4
+  FETAbs a1 e1 == FETAbs a2 e2 =
+    e1 == substTVarInFTerm a2 (TVar a1) e2 &&
+    e2 == substTVarInFTerm a1 (TVar a2) e1
+  FETApp e1 t1 == FETApp e2 t2 = e1 == e2 && t1 == t2
+  _ == _ = False
+
+instance Eq Type where
+  TVar a1 == TVar a2 = a1 == a2
+  TArrow t1 t2 == TArrow t3 t4 = t1 == t3 && t2 == t4
+  TForAll a1 t1 == TForAll a2 t2 =
+    t1 == substVarInType a2 (TVar a1) t2 &&
+    t2 == substVarInType a1 (TVar a2) t1
+  _ == _ = False
+
+-- Pretty printing
 class CollectParams a b | a -> b where
   collectParams :: a -> ([b], a)
 
-instance CollectParams Term String where
-  collectParams (EVar x) = ([], EVar x)
-  collectParams (EAbs x e1) =
+instance CollectParams ITerm String where
+  collectParams (IEVar x) = ([], IEVar x)
+  collectParams (IEAbs x e1) =
     let (xs, e2) = collectParams e1
-    in (x : xs, e2)
-  collectParams (EApp e1 e2) = ([], EApp e1 e2)
-  collectParams (EAnno e t) = ([], EAnno e t)
+    in (show x : xs, e2)
+  collectParams (IEApp e1 e2) = ([], IEApp e1 e2)
+  collectParams (IEAnno e t) = ([], IEAnno e t)
 
 instance CollectParams FTerm (String, String) where
   collectParams (FEVar x) = ([], FEVar x)
   collectParams (FEAbs x t e1) =
     let (xs, e2) = collectParams e1
-    in ((x, show t) : xs, e2)
+    in ((show x, show t) : xs, e2)
   collectParams (FEApp e1 e2) = ([], FEApp e1 e2)
-  collectParams (FETAbs x e1) =
+  collectParams (FETAbs a e1) =
     let (xs, e2) = collectParams e1
-    in ((x, "*") : xs, e2)
+    in ((show a, "*") : xs, e2)
   collectParams (FETApp e t) = ([], FETApp e t)
 
 instance CollectParams Type String where
-  collectParams (TVar x) = ([], TVar x)
+  collectParams (TVar a) = ([], TVar a)
   collectParams (TArrow t1 t2) = ([], TArrow t1 t2)
-  collectParams (TForAll x t1) =
-    let (xs, t2) = collectParams t1
-    in (x : xs, t2)
+  collectParams (TForAll a t1) =
+    let (as, t2) = collectParams t1
+    in (show a : as, t2)
 
 class PresentParams a where
   presentParams :: [a] -> String
@@ -85,23 +237,23 @@ instance PresentParams (String, String) where
       let t = snd (head group)
       return $ "(" ++ unwords ys ++ " : " ++ t ++ ")"
 
-instance Show Term where
-  show (EVar x) = x
-  show (EAbs x e1) =
-    let (xs, e2) = collectParams (EAbs x e1)
+instance Show ITerm where
+  show (IEVar x) = show x
+  show (IEAbs x e1) =
+    let (xs, e2) = collectParams (IEAbs x e1)
     in "λ" ++ presentParams xs ++ " . " ++ show e2
-  show (EApp (EAbs x e1) (EApp e2 e3)) =
-    "(" ++ show (EAbs x e1) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAbs x e1) e2) = "(" ++ show (EAbs x e1) ++ ") " ++ show e2
-  show (EApp (EAnno e1 t) (EApp e2 e3)) =
-    "(" ++ show (EAnno e1 t) ++ ") (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp (EAnno e1 t) e2) = "(" ++ show (EAnno e1 t) ++ ") " ++ show e2
-  show (EApp e1 (EApp e2 e3)) = show e1 ++ " (" ++ show (EApp e2 e3) ++ ")"
-  show (EApp e1 e2) = show e1 ++ " " ++ show e2
-  show (EAnno e t) = show e ++ " : " ++ show t
+  show (IEApp (IEAbs x e1) (IEApp e2 e3)) =
+    "(" ++ show (IEAbs x e1) ++ ") (" ++ show (IEApp e2 e3) ++ ")"
+  show (IEApp (IEAbs x e1) e2) = "(" ++ show (IEAbs x e1) ++ ") " ++ show e2
+  show (IEApp (IEAnno e1 t) (IEApp e2 e3)) =
+    "(" ++ show (IEAnno e1 t) ++ ") (" ++ show (IEApp e2 e3) ++ ")"
+  show (IEApp (IEAnno e1 t) e2) = "(" ++ show (IEAnno e1 t) ++ ") " ++ show e2
+  show (IEApp e1 (IEApp e2 e3)) = show e1 ++ " (" ++ show (IEApp e2 e3) ++ ")"
+  show (IEApp e1 e2) = show e1 ++ " " ++ show e2
+  show (IEAnno e t) = show e ++ " : " ++ show t
 
 instance Show FTerm where
-  show (FEVar x) = x
+  show (FEVar x) = show x
   show (FEAbs x t e1) =
     let (xs, e2) = collectParams (FEAbs x t e1)
     in "λ" ++ presentParams xs ++ " . " ++ show e2
@@ -111,26 +263,26 @@ instance Show FTerm where
     "(" ++ show (FEAbs x t1 e1) ++ ") (" ++ show (FETApp e2 t2) ++ ")"
   show (FEApp (FEAbs x t e1) e2) =
     "(" ++ show (FEAbs x t e1) ++ ") " ++ show e2
-  show (FEApp (FETAbs x e1) (FEApp e2 e3)) =
-    "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
-  show (FEApp (FETAbs x e1) (FETApp e2 t)) =
-    "(" ++ show (FETAbs x e1) ++ ") (" ++ show (FETApp e2 t) ++ ")"
-  show (FEApp (FETAbs x e1) e2) = "(" ++ show (FETAbs x e1) ++ ") " ++ show e2
+  show (FEApp (FETAbs a e1) (FEApp e2 e3)) =
+    "(" ++ show (FETAbs a e1) ++ ") (" ++ show (FEApp e2 e3) ++ ")"
+  show (FEApp (FETAbs a e1) (FETApp e2 t)) =
+    "(" ++ show (FETAbs a e1) ++ ") (" ++ show (FETApp e2 t) ++ ")"
+  show (FEApp (FETAbs a e1) e2) = "(" ++ show (FETAbs a e1) ++ ") " ++ show e2
   show (FEApp e1 (FEApp e2 e3)) = show e1 ++ " (" ++ show (FEApp e2 e3) ++ ")"
   show (FEApp e1 (FETApp e2 t)) = show e1 ++ " (" ++ show (FETApp e2 t) ++ ")"
   show (FEApp e1 e2) = show e1 ++ " " ++ show e2
-  show (FETAbs x e1) =
-    let (xs, e2) = collectParams (FETAbs x e1)
-    in "λ" ++ presentParams xs ++ " . " ++ show e2
+  show (FETAbs a e1) =
+    let (as, e2) = collectParams (FETAbs a e1)
+    in "λ" ++ presentParams as ++ " . " ++ show e2
   show (FETApp (FEAbs x t1 e) t2) =
     "(" ++ show (FEAbs x t1 e) ++ ") " ++ show t2
-  show (FETApp (FETAbs x e) t) = "(" ++ show (FETAbs x e) ++ ") " ++ show t
+  show (FETApp (FETAbs a e) t) = "(" ++ show (FETAbs a e) ++ ") " ++ show t
   show (FETApp e t) = show e ++ " " ++ show t
 
 instance Show Type where
-  show (TVar x) = x
-  show (TArrow (TVar x) t) = x ++ " -> " ++ show t
+  show (TVar a) = show a
+  show (TArrow (TVar a) t) = show a ++ " -> " ++ show t
   show (TArrow t1 t2) = "(" ++ show t1 ++ ") -> " ++ show t2
-  show (TForAll x t1) =
-    let (xs, t2) = collectParams (TForAll x t1)
-    in "∀" ++ presentParams xs ++ " . " ++ show t2
+  show (TForAll a t1) =
+    let (as, t2) = collectParams (TForAll a t1)
+    in "∀" ++ presentParams as ++ " . " ++ show t2


### PR DESCRIPTION
Implement a simple type inference algorithm for System F! Some examples from me using it in interactive mode:

```haskell
> \x . x : forall a . a -> a
  λ(a : *) (x : a) . x
  : ∀a . a -> a
> (\x . x : (forall a . a -> a) -> (forall b . b -> b)) (\y . y)
  (λ(x : ∀a . a -> a) (b : *) . x b) λ(a : *) (y : a) . y
  : ∀b . b -> b
> (\x y . x : forall a b . a -> b -> a) (\u v w . u (v w) : forall c d e . (d -> c) -> (e -> d) -> e -> c) (\z . z : forall f . f -> f)
  λ(a b : *) . (λ(b a : *) . (λ(a b : *) (x : a) (y : b) . x) ∀c d e . (d -> c) -> (e -> d) -> e -> c b λ(c d e : *) (u : d -> c) (v : e -> d) (w : e) . u (v w)) ∀f . f -> f a λ(f : *) (z : f) . z
  : ∀a b c d e . (d -> c) -> (e -> d) -> e -> c
```

It inserts some unnecessary type abstractions/applications, so I'm thinking of adding a simplification step after inference.

@esdrw 