### PR TITLE
Simplify the type checker

### DIFF
--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -31,7 +31,7 @@ import Syntax (EVar(..), TVar(..), ITerm(..), Type(..))
 %%
 
 ITerm : x                         { IEVar (ToEVar $1) }
-     | lambda VarList '.' ITerm   { foldr (\x e -> IEAbs (ToEVar x) e) $4 (reverse $2) }
+     | lambda VarList '->' ITerm  { foldr (\x e -> IEAbs (ToEVar x) e) $4 (reverse $2) }
      | ITerm ITerm %prec APP      { IEApp $1 $2 }
      | ITerm ':' Type             { IEAnno $1 $3 }
      | '(' ITerm ')'              { $2 }


### PR DESCRIPTION
Simplify some logic in the type checker/inferencer for System F. Also I changed the lambda notation from `\x . x` to `\x -> x` to be consistent with Haskell (I kept writing the wrong one).

@esdrw 