### PR TITLE
Simplify the logic further and eliminate unnecessary type abstractions and applications

### DIFF
--- a/.hindent.yaml
+++ b/.hindent.yaml
@@ -1,3 +1,3 @@
 indent-size: 2
-line-length: 79
+line-length: 78
 force-trailing-newline: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: \
   all test lint format clean \
   paper \
+    lint-general \
     lint-paper \
     clean-paper \
   formalization \
@@ -17,7 +18,9 @@ all: paper formalization implementation
 
 test: test-implementation
 
-lint: lint-paper lint-formalization lint-implementation
+lint: lint-general lint-paper lint-formalization lint-implementation
+
+lint-general:
 	./scripts/lint-general.rb $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -10,12 +10,10 @@ import Control.Monad (foldM, when)
 import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.Reader (Reader, ask, local, runReader)
 import Control.Monad.State (StateT, get, put, runStateT)
-import qualified Data.Bimap as Bimap
-import Data.Bimap (Bimap)
 import Data.List (foldl')
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Syntax
@@ -28,7 +26,7 @@ import Syntax
   , collectParams
   , presentParams
   , substEVarInTerm
-  , substVarInType
+  , substTVarInFTerm
   , tFreeVars
   )
 
@@ -95,6 +93,20 @@ substVarInPartialType a1 t1 (PTForAll a2 t2) =
   if a1 == a2
     then t2
     else substVarInPartialType a1 t1 t2
+
+substUnifierInPartialType ::
+     Unifier -> PartialType -> PartialType -> PartialType
+substUnifierInPartialType u1 t (PTUnifier u2) =
+  if u1 == u2
+    then t
+    else PTUnifier u2
+substUnifierInPartialType _ _ (PTVar a) = PTVar a
+substUnifierInPartialType u t1 (PTArrow t2 t3) =
+  PTArrow
+    (substUnifierInPartialType u t1 t2)
+    (substUnifierInPartialType u t1 t3)
+substUnifierInPartialType u t1 (PTForAll a t2) =
+  PTForAll a (substUnifierInPartialType u t1 t2)
 
 -- Contexts can hold term variables and type variables.
 type Context = (Map EVar Type, Set TVar)
@@ -166,28 +178,26 @@ makeTotal (PTForAll a t1) = do
   t2 <- makeTotal t1
   return $ TForAll a t2
 
--- Instantiate outer quantifiers with fresh type variables. Returns the type
--- and a list of the fresh variables.
-elimQuantifiers :: Type -> TypeCheck (Type, [TVar])
-elimQuantifiers (TVar a) = return (TVar a, [])
-elimQuantifiers (TArrow t1 t2) = return (TArrow t1 t2, [])
-elimQuantifiers (TForAll a1 t1) = do
-  a2 <- freshTVar (fromTVar a1)
-  (t2, as) <- elimQuantifiers (substVarInType a1 (TVar a2) t1)
-  return (t2, a2 : as)
+-- Instantiate outer quantifiers with fresh unifiers. Returns the type
+-- and a map from fresh unifiers to eliminated type variables.
+open :: PartialType -> TypeCheck (PartialType, [(Unifier, TVar)])
+open (PTUnifier u) = return (PTUnifier u, [])
+open (PTVar a) = return (PTVar a, [])
+open (PTArrow t1 t2) = return (PTArrow t1 t2, [])
+open (PTForAll a t1) = do
+  u <- freshUnifier (fromTVar a)
+  (t2, us) <- open (substVarInPartialType a (PTUnifier u) t1)
+  return (t2, (u, a) : us)
 
--- Check that the free variables of a type are bound in the context.
-ensureTypeWellFormed :: Type -> TypeCheck ()
-ensureTypeWellFormed t = mapM_ tLookupVar (tFreeVars t)
+-- This is needed when we need to eliminate type abstractions and we don't
+-- care what type we use.
+unitType :: Type
+unitType = TForAll (ToTVar "a") (TVar $ ToTVar "a")
 
--- Given a list of type variables, generate a fresh unifier for each.
-freshUnifiers :: [TVar] -> TypeCheck (Bimap TVar Unifier)
-freshUnifiers =
-  foldM
-    (\memo a -> do
-       u <- freshUnifier (fromTVar a)
-       return $ Bimap.insert a u memo)
-    Bimap.empty
+-- This function applies a term and a type, doing beta reduction if possible.
+applyType :: FTerm -> Type -> FTerm
+applyType (FETAbs a e) t = substTVarInFTerm a t e
+applyType e t = FETApp e t
 
 -- Find an instantiation that turns the second PartialType into the first.
 unify :: PartialType -> PartialType -> TypeCheck (Map Unifier Type)
@@ -215,7 +225,8 @@ unify (PTForAll a1 t1) (PTForAll a2 t2) = do
     "Unable to unify " ++
     show (PTForAll a1 t1) ++ " with " ++ show (PTForAll a2 t2)
   unify t1 (substVarInPartialType a2 (PTVar a1) t2)
-unify t1 t2 = throwError $ "Unable to unify " ++ show t1 ++ " with " ++ show t2
+unify t1 t2 =
+  throwError $ "Unable to unify " ++ show t1 ++ " with " ++ show t2
 
 -- Infer the type of a term.
 infer :: ITerm -> TypeCheck (FTerm, Type)
@@ -226,42 +237,42 @@ infer (IEApp e1 e2)
   -- Infer the type of e1.
  = do
   (e3, t1) <- infer e1
-  -- Eliminate the quantifiers to get the argument and return type of the
-  -- function.
-  (t2, as) <- elimQuantifiers t1
+  -- Instantiate all the outer quantifiers with fresh unifiers.
+  (t2, usAndAs) <- open (makePartial t1)
+  -- Get the argument and return types.
   (t3, t4) <-
     case t2 of
-      TArrow t3 t4 -> return (t3, t4)
+      PTArrow t3 t4 -> return (t3, t4)
       _ -> throwError $ "Not a function type: " ++ show t2
-  -- Replace variables from the eliminated quantifiers with fresh unifiers.
-  aToU <- freshUnifiers as
-  let t5 =
-        Map.foldrWithKey
-          substVarInPartialType
-          (makePartial t3)
-          (PTUnifier <$> Bimap.toMap aToU)
   -- Check the argument.
-  (e4, uToT) <- check e2 t5
-  -- Use the unification results to instantiate the quantifiers.
-  let (e6, t8) =
-        foldl'
-          (\(e5, t6) a ->
-             let t7 =
-                   fromMaybe
-                     (TVar a)
-                     (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT)
-             in (FETApp e5 t7, substVarInType a t7 t6))
-          (e3, t4)
-          as
-  -- Construct the application.
-  let e7 = FEApp e6 e4
+  (e4, uToT) <- check e2 t3
+  -- Wrap the applicand in type applications and substitute away the unifiers
+  -- in the return type.
+  (e5, t5, as) <-
+    foldM
+      (\(e5, t5, as) (u, a1) -> do
+         (t6, newAs) <-
+           case Map.lookup u uToT of
+             Just t6 -> return (t6, as)
+             Nothing -> do
+               a2 <- freshTVar (fromTVar a1)
+               return (TVar a2, a2 : as)
+         return
+           ( applyType e5 t6
+           , substUnifierInPartialType u (makePartial t6) t5
+           , newAs))
+      (e3, t4, [])
+      usAndAs
+  t6 <- makeTotal t5
+  -- Construct the application
+  let e6 = FEApp e5 e4
   -- Re-generalize the result.
-  return $ foldl' (\(e8, t6) a -> (FETAbs a e8, TForAll a t6)) (e7, t8) as
+  return $ foldl' (\(e7, t7) a -> (FETAbs a e7, TForAll a t7)) (e6, t6) as
 infer (IEAnno e1 t) = do
-  ensureTypeWellFormed t
+  mapM_ tLookupVar (tFreeVars t)
   (e2, _) <- check e1 (makePartial t)
   return (e2, t)
-infer t = throwError $ "Please annotate the type of: " ++ show t
+infer t = throwError $ "Unable to infer the type of: " ++ show t
 
 -- Check a term against a type and possibly instantiate unifiers in the type.
 check :: ITerm -> PartialType -> TypeCheck (FTerm, Map Unifier Type)
@@ -285,31 +296,23 @@ check e1 t1
   -- Infer the type of e1.
  = do
   (e2, t2) <- infer e1
-  -- Eliminate quantifiers in the resulting type so we can unify it with t1.
-  (t3, as) <- elimQuantifiers t2
-  -- Replace variables from the eliminated quantifiers with fresh unifiers.
-  aToU <- freshUnifiers as
-  let t4 =
-        Map.foldrWithKey
-          substVarInPartialType
-          (makePartial t3)
-          (PTUnifier <$> Bimap.toMap aToU)
+  -- Instantiate all the outer quantifiers with fresh unifiers.
+  (t3, usAndAs) <- open (makePartial t2)
   -- Unify the result with t1.
-  uToT1 <- unify t1 t4
-  -- Use the unification results to instantiate the quantifiers.
-  let (e4, t7) =
+  uToT1 <- unify t1 t3
+  -- Wrap the term in type applications and substitute away the unifiers in the
+  -- type.
+  let (e4, t6) =
         foldl'
-          (\(e3, t5) a ->
-             let t6 =
-                   fromMaybe
-                     (TVar $ ToTVar "unit")
-                     (Map.lookup (fromJust (Bimap.lookup a aToU)) uToT1)
-             in (FETApp e3 t6, substVarInType a t6 t5))
+          (\(e3, t4) (u, _) ->
+             let t5 = fromMaybe unitType (Map.lookup u uToT1)
+             in ( applyType e3 t5
+                , substUnifierInPartialType u (makePartial t5) t4))
           (e2, t3)
-          as
+          usAndAs
   -- Unify the original type against the inferred type with eliminated
   -- quantifiers.
-  uToT2 <- unify (makePartial t7) t1
+  uToT2 <- unify t6 t1
   return (e4, uToT2)
 
 -- Given a term in the untyped language, return a term in the typed language


### PR DESCRIPTION
Simplify the logic further and eliminate unnecessary type abstractions and applications.

Before:

```haskell
> (\x y -> x : forall a b . a -> b -> a) (\u v w -> u (v w) : forall c d e . (d -> c) -> (e -> d) -> e -> c) (\z -> z : forall f . f -> f)
  λ(a b : *) . (λ(b a : *) . (λ(a b : *) (x : a) (y : b) . x) ∀c d e . (d -> c) -> (e -> d) -> e -> c b λ(c d e : *) (u : d -> c) (v : e -> d) (w : e) . u (v w)) ∀f . f -> f a λ(f : *) (z : f) . z
  : ∀a b c d e . (d -> c) -> (e -> d) -> e -> c
```

Now:

```haskell
> (\x y -> x : forall a b . a -> b -> a) (\u v w -> u (v w) : forall c d e . (d -> c) -> (e -> d) -> e -> c) (\z -> z : forall f . f -> f)
  (λ(x : ∀c d e . (d -> c) -> (e -> d) -> e -> c) (y : ∀f . f -> f) . x) λ(c d e : *) (u : d -> c) (v : e -> d) (w : e) . u (v w) λ(f : *) (z : f) . z
  : ∀c d e . (d -> c) -> (e -> d) -> e -> c
```

@esdrw 