### PR TITLE
Implement evaluation

### DIFF
--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -3,6 +3,7 @@ module Main
   ) where
 
 import Data.Char (isSpace)
+import Evaluation (eval)
 import Inference (typeCheck)
 import Lexer (scan)
 import Parser (parse)
@@ -16,11 +17,15 @@ runProgram program =
     else do
       let result = do
             tokens <- scan program
-            term <- parse tokens
-            typeCheck term
+            iterm <- parse tokens
+            (fterm, ftype) <- typeCheck iterm
+            rterm <- eval fterm
+            return (fterm, ftype, rterm)
       case result of
         Left s -> putStrLn ("  " ++ s)
-        Right (e, t) -> putStrLn ("  " ++ show e ++ "\n  : " ++ show t)
+        Right (e, t, r) ->
+          putStrLn
+            ("  " ++ show e ++ "\n  : " ++ show t ++ "\n  => " ++ show r)
 
 main :: IO ()
 main = do

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -15,7 +15,8 @@ cabal-version:       >= 1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Inference
+  exposed-modules:     Evaluation
+                     , Inference
                      , Lexer
                      , Parser
                      , Syntax
@@ -41,7 +42,8 @@ test-suite implementation-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             LibSpec.hs
-  other-modules:       InferenceSpec
+  other-modules:       EvaluationSpec
+                     , InferenceSpec
                      , LexerSpec
                      , ParserSpec
                      , SyntaxSpec

--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -1,0 +1,24 @@
+module Evaluation
+  ( eval
+  ) where
+
+import Control.Monad.Except (throwError)
+import Syntax (FTerm(..), substEVarInFTerm, substTVarInFTerm)
+
+eval :: FTerm -> Either String FTerm
+eval (FEVar x) = throwError $ "Unbound variable: " ++ show x
+eval (FEAbs x t e) = return $ FEAbs x t e
+eval (FEApp e1 e2) = do
+  e3 <- eval e1
+  e4 <- eval e2
+  case e3 of
+    FEAbs x _ e5 -> return $ substEVarInFTerm x e4 e5
+    _ ->
+      throwError $ "Type error: cannot apply " ++ show e3 ++ " to " ++ show e4
+eval (FETAbs a e) = return $ FETAbs a e
+eval (FETApp e1 t) = do
+  e2 <- eval e1
+  case e2 of
+    FETAbs a e3 -> return $ substTVarInFTerm a t e3
+    _ ->
+      throwError $ "Type error: cannot apply " ++ show e2 ++ " to " ++ show t

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -152,7 +152,7 @@ eLookupVar x = do
   context <- ask
   case Map.lookup x (fst context) of
     Just t -> return t
-    Nothing -> throwError $ "Undefined term variable: " ++ show x
+    Nothing -> throwError $ "Undefined variable: " ++ show x
 
 -- Check that a type variable is in the context.
 tLookupVar :: TVar -> TypeCheck ()

--- a/implementation/test/EvaluationSpec.hs
+++ b/implementation/test/EvaluationSpec.hs
@@ -1,0 +1,9 @@
+module EvaluationSpec
+  ( evaluationSpec
+  ) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+-- The QuickCheck specs
+evaluationSpec :: Spec
+evaluationSpec = describe "eval" $ it "should be correct" pending


### PR DESCRIPTION
Implement (call-by-value) evaluation!

```haskell
> (\x -> x) (\y -> y)
  (λ(x : ∀a . a -> a) . x) λ(a : *) (y : a) . y
  : ∀a . a -> a
  => λ(a : *) (y : a) . y
> (\x y -> x) (\z -> z) (\w -> w)
  (λ(x : ∀a . a -> a) (a : *) (y : ∀a . a -> a) . x) λ(a : *) (z : a) . z ∀a . a -> a λ(a : *) (w : a) . w
  : ∀a . a -> a
  => λ(a : *) (z : ∀a . a -> a) . z
```

I'm puzzled about why `z` is the identity function in that second example though. Maybe that whole term has no principle type, so an arbitrary choice was made during type inference?

@esdrw 