### PR TITLE
Add let syntax which elaborates into a redex

### DIFF
--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -1,1 +1,2 @@
-\x -> x : forall a . a -> a
+let f = (\x -> x)
+in f (\y -> y)

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -23,7 +23,6 @@ library
   build-depends:       QuickCheck
                      , array
                      , base >= 4.7 && < 5
-                     , bimap
                      , containers
                      , mtl
   default-language:    Haskell2010
@@ -52,7 +51,6 @@ test-suite implementation-test
                      , hspec
                      , hspec-core
                      , QuickCheck
-                     , Stream
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -12,13 +12,13 @@ eval (FEApp e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case e3 of
-    FEAbs x _ e5 -> return $ substEVarInFTerm x e4 e5
+    FEAbs x _ e5 -> eval $ substEVarInFTerm x e4 e5
     _ ->
       throwError $ "Type error: cannot apply " ++ show e3 ++ " to " ++ show e4
 eval (FETAbs a e) = return $ FETAbs a e
 eval (FETApp e1 t) = do
   e2 <- eval e1
   case e2 of
-    FETAbs a e3 -> return $ substTVarInFTerm a t e3
+    FETAbs a e3 -> eval $ substTVarInFTerm a t e3
     _ ->
       throwError $ "Type error: cannot apply " ++ show e2 ++ " to " ++ show t

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -14,16 +14,19 @@ $alpha = [a-zA-Z]
 
 :-
 
-$white+                         ;
-"#".*                           ;
-":"                             { tokenAtom TokenAnno }
-"->"                            { tokenAtom TokenArrow }
-"."                             { tokenAtom TokenDot }
-"forall"                        { tokenAtom TokenForAll }
-@identifier                     { tokenString TokenId }
-"("                             { tokenAtom TokenLParen }
-"\"                             { tokenAtom TokenLambda }
-")"                             { tokenAtom TokenRParen }
+$white+     ;
+"#".*       ;
+"("         { tokenAtom TokenLParen }
+")"         { tokenAtom TokenRParen }
+"->"        { tokenAtom TokenArrow }
+"."         { tokenAtom TokenDot }
+":"         { tokenAtom TokenAnno }
+"="         { tokenAtom TokenEquals }
+"\"         { tokenAtom TokenLambda }
+"forall"    { tokenAtom TokenForAll }
+"in"        { tokenAtom TokenIn }
+"let"       { tokenAtom TokenLet }
+@identifier { tokenString TokenId }
 
 {
 
@@ -31,21 +34,27 @@ data Token
   = TokenAnno
   | TokenArrow
   | TokenDot
+  | TokenEquals
   | TokenForAll
   | TokenId String
+  | TokenIn
   | TokenLParen
   | TokenLambda
+  | TokenLet
   | TokenRParen
   deriving Eq
 
 instance Show Token where
+  show (TokenId x) = x
   show TokenAnno = ":"
   show TokenArrow = "->"
   show TokenDot = "."
+  show TokenEquals = "="
   show TokenForAll = "forall"
-  show (TokenId x) = x
+  show TokenIn = "in"
   show TokenLParen = "("
   show TokenLambda = "\\"
+  show TokenLet = "let"
   show TokenRParen = ")"
 
 alexScanAction :: Alex (Maybe Token)

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -9,45 +9,53 @@ import Syntax (EVar(..), TVar(..), ITerm(..), Type(..))
 
 %name parse
 %tokentype { Token }
-%monad { Either String }
-%error { parseError }
+%monad     { Either String }
+%error     { parseError }
 
 %token
-  ':'      { TokenAnno }
-  '->'     { TokenArrow }
-  '.'      { TokenDot }
-  forall   { TokenForAll }
-  x        { TokenId $$ }
-  '('      { TokenLParen }
-  lambda   { TokenLambda }
-  ')'      { TokenRParen }
+  '('    { TokenLParen }
+  ')'    { TokenRParen }
+  '->'   { TokenArrow }
+  '.'    { TokenDot }
+  ':'    { TokenAnno }
+  '='    { TokenEquals }
+  forall { TokenForAll }
+  in     { TokenIn }
+  lambda { TokenLambda }
+  let    { TokenLet }
+  x      { TokenId $$ }
 
-%nonassoc ':'
+%nonassoc ':' '=' in
 %left '.'
 %right '->'
-%nonassoc forall x '(' lambda ')'
+%nonassoc let forall x '(' lambda ')'
 %nonassoc APP
 
 %%
 
-ITerm : x                             { IEVar (UserEVar $1) }
-     | lambda EVarList '->' ITerm     { foldr (\(x, t) e -> IEAbs (UserEVar x) t e) $4 (reverse $2) }
-     | ITerm ITerm %prec APP          { IEApp $1 $2 }
-     | ITerm ':' Type                 { IEAnno $1 $3 }
-     | '(' ITerm ')'                  { $2 }
+ITerm
+  : x                          { IEVar (UserEVar $1) }
+  | lambda EVarList '->' ITerm { foldr (\(x, t) e -> IEAbs (UserEVar x) t e) $4 (reverse $2) }
+  | ITerm ITerm %prec APP      { IEApp $1 $2 }
+  | ITerm ':' Type             { IEAnno $1 $3 }
+  | let x '=' ITerm in ITerm   { IELet (UserEVar $2) $4 $6 }
+  | '(' ITerm ')'              { $2 }
 
-Type : x                              { TVar (UserTVar $1) }
-     | Type '->' Type                 { TArrow $1 $3 }
-     | forall TVarList '.' Type       { foldr (\x t -> TForAll (UserTVar x) t) $4 (reverse $2) }
-     | '(' Type ')'                   { $2 }
+Type
+  : x                        { TVar (UserTVar $1) }
+  | Type '->' Type           { TArrow $1 $3 }
+  | forall TVarList '.' Type { foldr (\x t -> TForAll (UserTVar x) t) $4 (reverse $2) }
+  | '(' Type ')'             { $2 }
 
-EVarList : x                          { [($1, Nothing)] }
-        | '(' x ':' Type ')'          { [($2, Just $4)] }
-        | EVarList x                  { ($2, Nothing) : $1 }
-        | EVarList '(' x ':' Type ')' { ($3, Just $5) : $1 }
+EVarList
+  : x                           { [($1, Nothing)] }
+  | '(' x ':' Type ')'          { [($2, Just $4)] }
+  | EVarList x                  { ($2, Nothing) : $1 }
+  | EVarList '(' x ':' Type ')' { ($3, Just $5) : $1 }
 
-TVarList : x                          { [$1] }
-        | TVarList x                  { $2 : $1 }
+TVarList
+  : x          { [$1] }
+  | TVarList x { $2 : $1 }
 
 {
 


### PR DESCRIPTION
For convenience, add let syntax which elaborates into a redex.

```haskell
> let f = (\x -> x) in f (\y -> y)
  (λ(f : ∀a . a -> a) . f ∀a . a -> a λ(a : *) (y : a) . y) λ(a : *) (x : a) . x
  : ∀a . a -> a
  => λ(a : *) (y : a) . y
```

I also fixed a bug in the evaluator.

@esdrw 