### PR TITLE
Add integers

### DIFF
--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -15,7 +15,8 @@ cabal-version:       >= 1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Evaluation
+  exposed-modules:     Context
+                     , Evaluation
                      , Inference
                      , Lexer
                      , Parser
@@ -41,7 +42,8 @@ test-suite implementation-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             LibSpec.hs
-  other-modules:       EvaluationSpec
+  other-modules:       ContextSpec
+                     , EvaluationSpec
                      , InferenceSpec
                      , LexerSpec
                      , ParserSpec

--- a/implementation/src/Context.hs
+++ b/implementation/src/Context.hs
@@ -1,0 +1,23 @@
+module Context
+  ( Context
+  , initialContext
+  , intType
+  ) where
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Syntax (EVar(..), TVar(..), Type(..))
+
+-- Contexts can hold term variables and type variables.
+type Context = (Map EVar Type, Set TVar)
+
+intTVar :: TVar
+intTVar = UserTVar "Int"
+
+intType :: Type
+intType = TVar intTVar
+
+initialContext :: Context
+initialContext = (Map.empty, Set.fromList [intTVar])

--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -6,6 +6,14 @@ import Control.Monad.Except (throwError)
 import Syntax (FTerm(..), substEVarInFTerm, substTVarInFTerm)
 
 eval :: FTerm -> Either String FTerm
+eval (FEIntLit i) = return $ FEIntLit i
+eval (FEAddInt e1 e2) = do
+  e3 <- eval e1
+  e4 <- eval e2
+  case (e3, e4) of
+    (FEIntLit i1, FEIntLit i2) -> return $ FEIntLit (i1 + i2)
+    _ ->
+      throwError $ "Type error: cannot add " ++ show e3 ++ " and " ++ show e4
 eval (FEVar x) = throwError $ "Unbound variable: " ++ show x
 eval (FEAbs x t e) = return $ FEAbs x t e
 eval (FEApp e1 e2) = do

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -18,6 +18,7 @@ $white+     ;
 "#".*       ;
 "("         { tokenAtom TokenLParen }
 ")"         { tokenAtom TokenRParen }
+"+"         { tokenAtom TokenPlus }
 "->"        { tokenAtom TokenArrow }
 "."         { tokenAtom TokenDot }
 ":"         { tokenAtom TokenAnno }
@@ -26,6 +27,7 @@ $white+     ;
 "forall"    { tokenAtom TokenForAll }
 "in"        { tokenAtom TokenIn }
 "let"       { tokenAtom TokenLet }
+$digit+     { tokenInteger TokenIntLit }
 @identifier { tokenString TokenId }
 
 {
@@ -38,14 +40,17 @@ data Token
   | TokenForAll
   | TokenId String
   | TokenIn
+  | TokenIntLit Integer
   | TokenLParen
   | TokenLambda
   | TokenLet
+  | TokenPlus
   | TokenRParen
   deriving Eq
 
 instance Show Token where
   show (TokenId x) = x
+  show (TokenIntLit x) = show x
   show TokenAnno = ":"
   show TokenArrow = "->"
   show TokenDot = "."
@@ -55,6 +60,7 @@ instance Show Token where
   show TokenLParen = "("
   show TokenLambda = "\\"
   show TokenLet = "let"
+  show TokenPlus = "+"
   show TokenRParen = ")"
 
 alexScanAction :: Alex (Maybe Token)
@@ -88,5 +94,8 @@ tokenAtom t = token (\_ _ -> Just t)
 
 tokenString :: (String -> Token) -> AlexAction (Maybe Token)
 tokenString t = token (\(_, _, _, s) len -> Just $ t (take len s))
+
+tokenInteger :: (Integer -> Token) -> AlexAction (Maybe Token)
+tokenInteger t = token (\(_, _, _, s) len -> Just $ t (read (take len s) :: Integer))
 
 }

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -15,29 +15,33 @@ import Syntax (EVar(..), TVar(..), ITerm(..), Type(..))
 %token
   '('    { TokenLParen }
   ')'    { TokenRParen }
+  '+'    { TokenPlus }
   '->'   { TokenArrow }
   '.'    { TokenDot }
   ':'    { TokenAnno }
   '='    { TokenEquals }
   forall { TokenForAll }
+  i      { TokenIntLit $$ }
   in     { TokenIn }
   lambda { TokenLambda }
   let    { TokenLet }
   x      { TokenId $$ }
 
-%nonassoc ':' '=' in
-%left '.'
+%nonassoc ':' '=' in '.'
 %right '->'
-%nonassoc let forall x '(' lambda ')'
+%left '+'
+%nonassoc let forall lambda '(' ')' x i
 %nonassoc APP
 
 %%
 
 ITerm
-  : x                          { IEVar (UserEVar $1) }
+  : i                          { IEIntLit $1 }
+  | x                          { IEVar (UserEVar $1) }
   | lambda EVarList '->' ITerm { foldr (\(x, t) e -> IEAbs (UserEVar x) t e) $4 (reverse $2) }
   | ITerm ITerm %prec APP      { IEApp $1 $2 }
   | ITerm ':' Type             { IEAnno $1 $3 }
+  | ITerm '+' ITerm            { IEAddInt $1 $3 }
   | let x '=' ITerm in ITerm   { IELet (UserEVar $2) $4 $6 }
   | '(' ITerm ')'              { $2 }
 

--- a/implementation/test/ContextSpec.hs
+++ b/implementation/test/ContextSpec.hs
@@ -1,0 +1,9 @@
+module ContextSpec
+  ( contextSpec
+  ) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+-- The QuickCheck specs
+contextSpec :: Spec
+contextSpec = describe "context" $ it "should be correct" pending


### PR DESCRIPTION
Add integers and addition—a monoid!

```haskell
let f = \x -> x + x : Int -> Int in
let g = \x -> f (f x) : Int -> Int in
f 3 + g 4
```

I also simplified the `Show` instances for terms because I was getting tired of maintaining them. Now they always use parentheses to eliminate ambiguity, even when they aren't strictly needed.

@esdrw 