### PR TITLE
Make unification work in both directions

### DIFF
--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -1,4 +1,4 @@
+let apply = \f -> f : forall a b . (a -> b) -> a -> b in
+let double = \x -> x + x : Int -> Int in
 let twice = \(f : Int -> Int) (x : Int) -> f (f x) in
-let add = \(x : Int) (y : Int) -> x + y in
-let double = \(x : Int) -> add x x in
-twice double 4
+apply twice double 4

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -178,8 +178,8 @@ makeTotal (PTForAll a t1) = do
   t2 <- makeTotal t1
   return $ TForAll a t2
 
--- Instantiate outer quantifiers with fresh unifiers. Returns the type
--- and a map from fresh unifiers to eliminated type variables.
+-- Instantiate outer quantifiers with fresh unifiers. Returns the type and a
+-- list of fresh unifiers paired with the eliminated type variables.
 open :: PartialType -> TypeCheck (PartialType, [(Unifier, TVar)])
 open (PTUnifier u) = return (PTUnifier u, [])
 open (PTVar a) = return (PTVar a, [])
@@ -189,8 +189,8 @@ open (PTForAll a t1) = do
   (t2, us) <- open (substVarInPartialType a (PTUnifier u) t1)
   return (t2, (u, a) : us)
 
--- This is needed when we need to eliminate type abstractions and we don't
--- care what type we use.
+-- This is needed when we need to eliminate type abstractions and we don't care
+-- what type we use.
 unitType :: Type
 unitType = TForAll (FreshTVar "a") (TVar $ FreshTVar "a")
 
@@ -209,9 +209,12 @@ checkInst uToT1 uToT2 s =
     then return ()
     else throwError s
 
--- Find an instantiation that turns the second PartialType into the first.
+-- Find an instantiation that equates two PartialTypes.
 unify :: PartialType -> PartialType -> TypeCheck (Map Unifier Type)
 unify t1 (PTUnifier u) = do
+  t2 <- makeTotal t1
+  return $ Map.singleton u t2
+unify (PTUnifier u) t1 = do
   t2 <- makeTotal t1
   return $ Map.singleton u t2
 unify (PTVar a1) (PTVar a2) =


### PR DESCRIPTION
Previously, the `unify` function would try to instantiate variables to turn one type into another. Now, it can instantiate variables in both types to equate them. This allows more programs to type check without annotations. For example, this was previously rejected but works now:

```haskell
let apply = \f -> f : forall a b . (a -> b) -> a -> b in
let double = \x -> x + x : Int -> Int in
let twice = \(f : Int -> Int) (x : Int) -> f (f x) in
apply twice double 4
```

The inferred System F term is:

```haskell
((λ(apply : ∀a b . (a -> b) -> a -> b) . ((λ(double : Int -> Int) . ((λ(twice : (Int -> Int) -> Int -> Int) . (((((apply Int -> Int) Int -> Int) twice) double) 4)) (λ(f : Int -> Int) (x : Int) . (f (f x))))) (λ(x : Int) . (x + x)))) (λ(a b : *) (f : a -> b) . f))
```

And it's type is:

```haskell
Int
```

And evaluation produces:

```haskell
16
```

😄 

@esdrw 