### PR TITLE
Add a fun example: Church-encoded lists

### DIFF
--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -1,4 +1,23 @@
-let apply = \f -> f : forall a b . (a -> b) -> a -> b in
-let double = \x -> x + x : Int -> Int in
-let twice = \(f : Int -> Int) (x : Int) -> f (f x) in
-apply twice double 4
+# This is the Church encoding of lists.
+let nil = \i f -> i
+  : forall a b
+  . b
+  -> (a -> b -> b)
+  -> b in
+
+let cons = \x l i f -> l (f x i) f
+  : forall a
+  . a
+  -> (forall b . b -> (a -> b -> b) -> b)
+  -> forall b . b -> (a -> b -> b) -> b in
+
+# This computes the sum of a list of integers.
+let sum = \l -> l 0 (\x y -> x + y)
+  : (forall a . a -> (Int -> a -> a) -> a)
+  -> Int in
+
+# Here's a list containing three numbers.
+let myList = cons 3 (cons 4 (cons 5 nil)) in
+
+# Let's take its sum.
+sum myList


### PR DESCRIPTION
Add a fun example: Church-encoded lists.

```haskell
# This is the Church encoding of lists.
let nil = \i f -> i
  : forall a b
  . b
  -> (a -> b -> b)
  -> b in

let cons = \x l i f -> l (f x i) f
  : forall a
  . a
  -> (forall b . b -> (a -> b -> b) -> b)
  -> forall b . b -> (a -> b -> b) -> b in

# This computes the sum of a list of integers.
let sum = \l -> l 0 (\x y -> x + y)
  : (forall a . a -> (Int -> a -> a) -> a)
  -> Int in

# Here's a list containing three numbers.
let myList = cons 3 (cons 4 (cons 5 nil)) in

# Let's take its sum.
sum myList
```

The result:

```haskell
((λ(nil : ∀a b . b -> (a -> b -> b) -> b) . ((λ(cons : ∀a . a -> (∀b . b -> (a -> b -> b) -> b) -> ∀b . b -> (a -> b -> b) -> b) . ((λ(sum : (∀a . a -> (Int -> a -> a) -> a) -> Int) . ((λ(myList : ∀b . b -> (Int -> b -> b) -> b) . (sum (λ(a : *) . (myList a)))) (((cons Int) 3) (λ(b : *) . ((((cons Int) 4) (λ(@4 : *) . ((((cons Int) 5) (λ(@6 : *) . ((nil Int) @6))) @4))) b))))) (λ(l : ∀a . a -> (Int -> a -> a) -> a) . (((l Int) 0) (λ(x y : Int) . (x + y)))))) (λ(a : *) (x : a) (l : ∀b . b -> (a -> b -> b) -> b) (b : *) (i : b) (f : a -> b -> b) . (((l b) ((f x) i)) f)))) (λ(a b : *) (i : b) (f : a -> b -> b) . i))
: Int
=> 12
```

@esdrw 