### PR TITLE
Introduce a slightly shorter form of lambda syntax

### DIFF
--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -12,7 +12,7 @@ let cons = \x l i f -> l (f x i) f
   -> forall b . b -> (a -> b -> b) -> b in
 
 # This computes the sum of a list of integers.
-let sum = \l -> l 0 (\x y -> x + y)
+let sum = l -> l 0 (\x y -> x + y)
   : (forall a . a -> (Int -> a -> a) -> a)
   -> Int in
 

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -42,6 +42,7 @@ import Syntax (EVar(..), ITerm(..), TVar(..), Type(..))
 ITerm
   : i                          { IEIntLit $1 }
   | x                          { IEVar (UserEVar $1) }
+  | x '->' ITerm               { IEAbs (UserEVar $1) Nothing $3 }
   | lambda EVarList '->' ITerm { foldr (\(x, t) e -> IEAbs (UserEVar x) t e) $4 (reverse $2) }
   | ITerm ITerm %prec APP      { IEApp $1 $2 }
   | ITerm ':' Type             { IEAnno $1 $3 }


### PR DESCRIPTION
Introduce a slightly shorter form of lambda syntax. Now, instead of `\x -> x`, we can just write `x -> x`. For multiple arguments, you can still write `\x y z -> x`. Variables can be annotated in the longer version as well: `\(x : Int) -> x`.

@esdrw 