### PR TITLE
Add support for readline

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -1,8 +1,29 @@
-# Implementation
+# Demo
 
-To run the demo, use either of the following:
+First, make sure the dependencies listed below are installed. Then you can build the demo with:
+
+```sh
+stack build --pedantic --install-ghc --allow-different-user
+```
+
+Use either of the following to run the demo:
 
 ```sh
 stack exec implementation-exe
 stack exec implementation-exe <path>
+```
+
+## Dependencies
+
+- [Stack](https://docs.haskellstack.org/en/stable/README/): This can be installed via `curl -sSL https://get.haskellstack.org/ | sh` on many platforms.
+- [GNU Readline](https://tiswww.case.edu/php/chet/readline/rltop.html): This can be
+installed via `brew install readline` (macOS) or `apt-get install libreadline-dev` (Debian).
+
+## Troubleshooting
+
+If you get an error when compiling the `readline` package, set the `CFLAGS` and `LDFLAGS` environment variables to help the compiler locate the GNU Readline installation. For example, if you installed Readline via `brew install readline`, then you probably need this:
+
+```
+export CFLAGS="$CFLAGS -I/usr/local/opt/readline/include"
+export LDFLAGS="$LDFLAGS -L/usr/local/opt/readline/lib"
 ```

--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -7,8 +7,8 @@ import Evaluation (eval)
 import Inference (typeCheck)
 import Lexer (scan)
 import Parser (parse)
+import System.Console.Readline (addHistory, readline)
 import System.Environment (getArgs)
-import System.IO (hFlush, stdout)
 
 runProgram :: String -> IO ()
 runProgram program =
@@ -36,10 +36,12 @@ main = do
       runProgram program
     [] ->
       let repl = do
-            putStr "> "
-            hFlush stdout
-            program <- getLine
-            runProgram program
-            repl
+            input <- readline "> "
+            case input of
+              Just program -> do
+                addHistory program
+                runProgram program
+                repl
+              Nothing -> return ()
       in repl
     _ -> putStrLn "Usage:\n  implementation-exe\n  implementation-exe <path>"

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -36,6 +36,7 @@ executable implementation-exe
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , implementation
+                     , readline
   default-language:    Haskell2010
 
 test-suite implementation-test

--- a/implementation/stack.yaml
+++ b/implementation/stack.yaml
@@ -42,6 +42,7 @@ packages:
 extra-deps:
 - Stream-0.4.7.2
 - lazysmallcheck-0.6 # Needed by Stream
+- readline-1.0.3.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,6 +4,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     'build-essential=12.3' \
+    'libreadline-dev=7.0-*' \
     'python-pip=9.0.*' \
     'ruby=1:2.3.*' \
     'texlive-full=2016.*' && \


### PR DESCRIPTION
Add support for readline! This makes the REPL much nicer to use. You can navigate and search command history and...drumroll...use backspace! 😄 

I don't think Stack has a way to conditionally compile with readline depending on some flag. So, for now, readline is now a hard dependency. Unfortunately, users may need to set the `CFLAGS` and `LDFLAGS` flags to make this work (e.g., in their `.bashrc` or whatever), or else Stack will fail to build the `readline` package. It's ridiculous how primitive the process is for installing and using system libraries in 2018.

cc @esdrw 