### PR TITLE
Switch from the 'in' keyword to semicolons

### DIFF
--- a/implementation/examples/test.g
+++ b/implementation/examples/test.g
@@ -3,21 +3,21 @@ nil = \i f -> i
   : forall a b
   . b
   -> (a -> b -> b)
-  -> b in
+  -> b;
 
 cons = \x l i f -> l (f x i) f
   : forall a b
   . a
   -> (forall c . c -> (a -> c -> c) -> c)
-  -> b -> (a -> b -> b) -> b in
+  -> b -> (a -> b -> b) -> b;
 
 # This computes the sum of a list of integers.
 sum = l -> l 0 (\x y -> x + y)
   : (forall a . a -> (Int -> a -> a) -> a)
-  -> Int in
+  -> Int;
 
 # Here's a list containing three numbers.
-myList = cons 3 (cons 4 (cons 5 nil)) in
+myList = cons 3 (cons 4 (cons 5 nil));
 
 # Let's take its sum.
 sum myList

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -27,10 +27,10 @@ $idChar = [_ $lower $upper $digit]
 "."            { tokenAtom TokenDot }
 "/"            { tokenAtom TokenSlash }
 ":"            { tokenAtom TokenAnno }
+";"            { tokenAtom TokenSemicolon }
 "="            { tokenAtom TokenEquals }
 "\" | "λ"      { tokenAtom TokenLambda }
 "forall" | "∀" { tokenAtom TokenForAll }
-"in"           { tokenAtom TokenIn }
 $digit+        { tokenInteger TokenIntLit }
 $white+        ;
 @idLower       { tokenString TokenIdLower }
@@ -48,12 +48,12 @@ data Token
   | TokenForAll
   | TokenIdLower String
   | TokenIdUpper String
-  | TokenIn
   | TokenIntLit Integer
   | TokenLParen
   | TokenLambda
   | TokenPlus
   | TokenRParen
+  | TokenSemicolon
   | TokenSlash
   deriving Eq
 
@@ -68,11 +68,11 @@ instance Show Token where
   show TokenDot = "."
   show TokenEquals = "="
   show TokenForAll = "∀"
-  show TokenIn = "in"
   show TokenLParen = "("
   show TokenLambda = "λ"
   show TokenPlus = "+"
   show TokenRParen = ")"
+  show TokenSemicolon = ";"
   show TokenSlash = "/"
 
 alexScanAction :: Alex (Maybe Token)

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -29,15 +29,15 @@ import Syntax
   '.'    { TokenDot }
   '/'    { TokenSlash }
   ':'    { TokenAnno }
+  ';'    { TokenSemicolon }
   '='    { TokenEquals }
+  X      { TokenIdUpper $$ }
   forall { TokenForAll }
   i      { TokenIntLit $$ }
-  in     { TokenIn }
   lambda { TokenLambda }
   x      { TokenIdLower $$ }
-  X      { TokenIdUpper $$ }
 
-%nonassoc ':' '=' in '.'
+%nonassoc ':' '=' ';' '.'
 %right '->'
 %left '+' '-'
 %left '*' '/'
@@ -57,7 +57,7 @@ ITerm
   | ITerm '-' ITerm            { IESubInt $1 $3 }
   | ITerm '*' ITerm            { IEMulInt $1 $3 }
   | ITerm '/' ITerm            { IEDivInt $1 $3 }
-  | x '=' ITerm in ITerm       { IELet (EVarName $1) $3 $5 }
+  | x '=' ITerm ';' ITerm       { IELet (EVarName $1) $3 $5 }
   | '(' ITerm ')'              { $2 }
 
 Type


### PR DESCRIPTION
Switch from the `in` keyword to semicolons.

<img width="563" alt="screenshot 2018-05-09 19 46 31" src="https://user-images.githubusercontent.com/796574/39849579-dd3db846-53c1-11e8-8a38-a13564a20db6.png">

I think it's a little bit nicer since there isn't a `let` keyword.

@esdrw 