### PR TITLE
Add Booleans and conditionals

### DIFF
--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -42,6 +42,16 @@ eval (FEDivInt e1 e2) = do
     _ ->
       throwError $
       "Type error: cannot divide " ++ show e3 ++ " and " ++ show e4
+eval FETrue = return FETrue
+eval FEFalse = return FEFalse
+eval (FEIf e1 e2 e3) = do
+  e4 <- eval e1
+  e5 <- eval e2
+  e6 <- eval e3
+  case e4 of
+    FETrue -> return e5
+    FEFalse -> return e6
+    _ -> throwError $ "Type error: " ++ show e4 ++ " is not a Boolean"
 eval (FEVar x) = throwError $ "Unbound variable: " ++ show x
 eval (FEAbs x t e) = return $ FEAbs x t e
 eval (FEApp e1 e2) = do

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -30,7 +30,12 @@ $idChar = [_ $lower $upper $digit]
 ";"            { tokenAtom TokenSemicolon }
 "="            { tokenAtom TokenEquals }
 "\" | "λ"      { tokenAtom TokenLambda }
+"else"         { tokenAtom TokenElse }
+"false"        { tokenAtom TokenFalse }
 "forall" | "∀" { tokenAtom TokenForAll }
+"if"           { tokenAtom TokenIf }
+"then"         { tokenAtom TokenThen }
+"true"         { tokenAtom TokenTrue }
 $digit+        { tokenInteger TokenIntLit }
 $white+        ;
 @idLower       { tokenString TokenIdLower }
@@ -44,10 +49,13 @@ data Token
   | TokenAsterisk
   | TokenDash
   | TokenDot
+  | TokenElse
   | TokenEquals
+  | TokenFalse
   | TokenForAll
   | TokenIdLower String
   | TokenIdUpper String
+  | TokenIf
   | TokenIntLit Integer
   | TokenLParen
   | TokenLambda
@@ -55,6 +63,8 @@ data Token
   | TokenRParen
   | TokenSemicolon
   | TokenSlash
+  | TokenThen
+  | TokenTrue
   deriving Eq
 
 instance Show Token where
@@ -66,14 +76,19 @@ instance Show Token where
   show TokenAsterisk = "*"
   show TokenDash = "-"
   show TokenDot = "."
+  show TokenElse = "else"
   show TokenEquals = "="
+  show TokenFalse = "false"
   show TokenForAll = "∀"
+  show TokenIf = "if"
   show TokenLParen = "("
   show TokenLambda = "λ"
   show TokenPlus = "+"
   show TokenRParen = ")"
   show TokenSemicolon = ";"
   show TokenSlash = "/"
+  show TokenThen = "then"
+  show TokenTrue = "true"
 
 alexScanAction :: Alex (Maybe Token)
 alexScanAction = do

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -32,33 +32,41 @@ import Syntax
   ';'    { TokenSemicolon }
   '='    { TokenEquals }
   X      { TokenIdUpper $$ }
+  else   { TokenElse }
+  false  { TokenFalse }
   forall { TokenForAll }
   i      { TokenIntLit $$ }
+  if     { TokenIf }
   lambda { TokenLambda }
+  then   { TokenThen }
+  true   { TokenTrue }
   x      { TokenIdLower $$ }
 
-%nonassoc ':' '=' ';' '.'
+%nonassoc ':' '=' ';' '.' true false then else
 %right '->'
 %left '+' '-'
 %left '*' '/'
-%nonassoc let exists forall lambda '(' ')' x i
+%nonassoc let exists forall lambda '(' ')' x i if
 %nonassoc APP
 
 %%
 
 ITerm
-  : i                          { IEIntLit $1 }
-  | x                          { IEVar (EVarName $1) }
-  | x '->' ITerm               { IEAbs (EVarName $1) Nothing $3 }
-  | lambda EVarList '->' ITerm { foldr (\(x, t) e -> IEAbs x t e) $4 (reverse $2) }
-  | ITerm ITerm %prec APP      { IEApp $1 $2 }
-  | ITerm ':' Type             { IEAnno (annotate $1 $3) $3 }
-  | ITerm '+' ITerm            { IEAddInt $1 $3 }
-  | ITerm '-' ITerm            { IESubInt $1 $3 }
-  | ITerm '*' ITerm            { IEMulInt $1 $3 }
-  | ITerm '/' ITerm            { IEDivInt $1 $3 }
-  | x '=' ITerm ';' ITerm       { IELet (EVarName $1) $3 $5 }
-  | '(' ITerm ')'              { $2 }
+  : i                              { IEIntLit $1 }
+  | ITerm '+' ITerm                { IEAddInt $1 $3 }
+  | ITerm '-' ITerm                { IESubInt $1 $3 }
+  | ITerm '*' ITerm                { IEMulInt $1 $3 }
+  | ITerm '/' ITerm                { IEDivInt $1 $3 }
+  | true                           { IETrue }
+  | false                          { IEFalse }
+  | if ITerm then ITerm else ITerm { IEIf $2 $4 $6 }
+  | x                              { IEVar (EVarName $1) }
+  | x '->' ITerm                   { IEAbs (EVarName $1) Nothing $3 }
+  | lambda EVarList '->' ITerm     { foldr (\(x, t) e -> IEAbs x t e) $4 (reverse $2) }
+  | ITerm ITerm %prec APP          { IEApp $1 $2 }
+  | ITerm ':' Type                 { IEAnno (annotate $1 $3) $3 }
+  | x '=' ITerm ';' ITerm          { IELet (EVarName $1) $3 $5 }
+  | '(' ITerm ')'                  { $2 }
 
 Type
   : x                        { TVar (UserTVarName $1) }


### PR DESCRIPTION
Add Booleans and conditionals (`if`/`then`/`else`). It's easier to play around with when there are a few basic types at your disposal. It's also interesting to see how this interacts with type inference:

<img width="1097" alt="screenshot 2018-05-10 03 25 51" src="https://user-images.githubusercontent.com/796574/39865488-e9429810-5401-11e8-97d3-81e348ccdab6.png">

So the "type" of `if` (if it were a function) is `∀α . Bool → α → α → α`.

@esdrw 