### PR TITLE
Add support for lists and other N-ary constructors

### DIFF
--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -2,6 +2,7 @@ module Evaluation
   ( eval
   ) where
 
+import Control.Monad (foldM)
 import Control.Monad.Except (throwError)
 import Syntax (FTerm(..), subst)
 
@@ -44,6 +45,15 @@ eval (FEIf e1 e2 e3) = do
     FETrue -> return e5
     FEFalse -> return e6
     _ -> throwError $ show e4 ++ " is not a Boolean"
+eval (FEList es1) = do
+  es2 <-
+    foldM
+      (\es2 e1 -> do
+         e2 <- eval e1
+         return $ e2 : es2)
+      []
+      es1
+  return $ FEList $ reverse es2
 eval (FEVar x) = throwError $ "Unbound variable: " ++ show x
 eval (FEAbs x t e) = return $ FEAbs x t e
 eval (FEApp e1 e2) = do

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -22,6 +22,7 @@ $idChar = [_ $lower $upper $digit]
 ")"            { tokenAtom TokenRParen }
 "*"            { tokenAtom TokenAsterisk }
 "+"            { tokenAtom TokenPlus }
+","            { tokenAtom TokenComma }
 "-"            { tokenAtom TokenDash }
 "->" | "→"     { tokenAtom TokenArrow }
 "."            { tokenAtom TokenDot }
@@ -29,7 +30,9 @@ $idChar = [_ $lower $upper $digit]
 ":"            { tokenAtom TokenAnno }
 ";"            { tokenAtom TokenSemicolon }
 "="            { tokenAtom TokenEquals }
+"["            { tokenAtom TokenLSquare }
 "\" | "λ"      { tokenAtom TokenLambda }
+"]"            { tokenAtom TokenRSquare }
 "else"         { tokenAtom TokenElse }
 "false"        { tokenAtom TokenFalse }
 "forall" | "∀" { tokenAtom TokenForAll }
@@ -47,6 +50,7 @@ data Token
   = TokenAnno
   | TokenArrow
   | TokenAsterisk
+  | TokenComma
   | TokenDash
   | TokenDot
   | TokenElse
@@ -58,9 +62,11 @@ data Token
   | TokenIf
   | TokenIntLit Integer
   | TokenLParen
+  | TokenLSquare
   | TokenLambda
   | TokenPlus
   | TokenRParen
+  | TokenRSquare
   | TokenSemicolon
   | TokenSlash
   | TokenThen
@@ -74,6 +80,7 @@ instance Show Token where
   show TokenAnno = ":"
   show TokenArrow = "→"
   show TokenAsterisk = "*"
+  show TokenComma = ","
   show TokenDash = "-"
   show TokenDot = "."
   show TokenElse = "else"
@@ -82,9 +89,11 @@ instance Show Token where
   show TokenForAll = "∀"
   show TokenIf = "if"
   show TokenLParen = "("
+  show TokenLSquare = "["
   show TokenLambda = "λ"
   show TokenPlus = "+"
   show TokenRParen = ")"
+  show TokenRSquare = "]"
   show TokenSemicolon = ";"
   show TokenSlash = "/"
   show TokenThen = "then"


### PR DESCRIPTION
Add support for lists and other N-ary constructors (but the only one currently is lists).

<img width="814" alt="screenshot 2018-05-10 23 47 53" src="https://user-images.githubusercontent.com/796574/39910540-97a7382a-54ac-11e8-80fb-b4ecfd99b6b3.png">

Right now you can't do anything with lists; you can only construct them. 😛

@esdrw 