### PR TITLE
Delete effect rows

### DIFF
--- a/paper/calculus.tex
+++ b/paper/calculus.tex
@@ -1,6 +1,6 @@
 \section{The calculus}
 
-  We adopt the familiar conventions that alpha-equivalent expressions are interchangeable and that bound variables are distinct from free variables in all contexts. We have a monoidal structure on effect rows $\row$ with $\tPure$ as the identity element. Additionally, we identify effect rows up to commutativity and idempotency, that is, $\tUnion{\row_1}{\row_2} = \tUnion{\row_2}{\row_1}$ for any $\row_1, \row_2$ and $\tUnion{\row}{\row} = \row$ for any $\row$.
+  We adopt the familiar conventions that alpha-equivalent expressions are interchangeable and that bound variables are distinct from free variables in all contexts.
 
   \subsection{Syntax}
 
@@ -19,17 +19,16 @@
           & $\eRun{\term}$ & computation elimination \\
           & $\eDo{\eVar}{\term}{\term}$ & computation sequencing \\
           \\
-          $\type, \row \Coloneqq$ & & types: \\
+          $\type, \effect \Coloneqq$ & & types: \\
           & $\tVar$ & type variable \\
           & $\tArrow{\type}{\type}$ & arrow type \\
           & $\tForAll{\tVar}{\kind}{\type}$ & universal type \\
-          & $\tComputation{\type}{\row}$ & computation type \\
-          & $\tPure$ & pure row \\
-          & $\tUnion{\row}{\row}$ & row union \\
+          & $\tComputation{\type}{\effect}$ & computation type \\
+          & $\tPure$ & pure effect \\
           \\
           $\kind \Coloneqq$ & & kinds: \\
           & $\kType$ & kind of proper types \\
-          & $\kRow$ & kind of rows \\
+          & $\kEffect$ & kind of rows \\
           & $\kWitness{\type}$ & kind of witnesses \\
           \\
           $\context \Coloneqq$ & & contexts: \\
@@ -102,17 +101,17 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hasType{\context}{\term_1}{\tComputation{\type_1}{\row}}$}
-          \AxiomC{$\hasType{\cEExtend{\context}{\eVar}{\type_1}}{\term_2}{\tComputation{\type_2}{\row}}$}
+          \AxiomC{$\hasType{\context}{\term_1}{\tComputation{\type_1}{\effect}}$}
+          \AxiomC{$\hasType{\cEExtend{\context}{\eVar}{\type_1}}{\term_2}{\tComputation{\type_2}{\effect}}$}
         \RightLabel{(\textsc{T-Do})}
-        \BinaryInfC{$\hasType{\context}{\eDo{\eVar}{\term_1}{\term_2}}{\tComputation{\type_2}{\row}}$}
+        \BinaryInfC{$\hasType{\context}{\eDo{\eVar}{\term_1}{\term_2}}{\tComputation{\type_2}{\effect}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\hasType{\context}{\term}{\type}$}
-          \AxiomC{$\hasKind{\context}{\row}{\kRow}$}
+          \AxiomC{$\hasKind{\context}{\effect}{\kEffect}$}
         \RightLabel{(\textsc{T-Pure})}
-        \BinaryInfC{$\hasType{\context}{\ePure{\term}}{\tComputation{\type}{\row}}$}
+        \BinaryInfC{$\hasType{\context}{\ePure{\term}}{\tComputation{\type}{\effect}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -153,22 +152,15 @@
 
       \begin{prooftree}
           \AxiomC{$\hasKind{\context}{\type}{\kType}$}
-          \AxiomC{$\hasKind{\context}{\row}{\kRow}$}
+          \AxiomC{$\hasKind{\context}{\effect}{\kEffect}$}
         \RightLabel{(\textsc{K-Computation})}
-        \BinaryInfC{$\hasKind{\context}{\tComputation{\type}{\row}}{\kType}$}
+        \BinaryInfC{$\hasKind{\context}{\tComputation{\type}{\effect}}{\kType}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{K-Pure})}
-        \UnaryInfC{$\hasKind{\context}{\tPure}{\kRow}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\row_1}{\kRow}$}
-          \AxiomC{$\hasKind{\context}{\row_2}{\kRow}$}
-        \RightLabel{(\textsc{K-Union})}
-        \BinaryInfC{$\hasKind{\context}{\tUnion{\row_1}{\row_2}}{\kRow}$}
+        \UnaryInfC{$\hasKind{\context}{\tPure}{\kEffect}$}
       \end{prooftree}
 
       \caption{Kinding rules}
@@ -237,7 +229,7 @@
         \qquad
           \AxiomC{$\translatesTo{\context}{\term_1}{\term_2}$}
         \RightLabel{(\textsc{S-TAbs2})}
-        \UnaryInfC{$\translatesTo{\context}{\eTAbs{\tVar}{\kRow}{\term_1}}{\eTAbsNoKind{\tVar}{\term_2}}$}
+        \UnaryInfC{$\translatesTo{\context}{\eTAbs{\tVar}{\kEffect}{\term_1}}{\eTAbsNoKind{\tVar}{\term_2}}$}
         \DisplayProof
       \end{center}
 
@@ -386,11 +378,11 @@
       \begin{center}
           \AxiomC{$\translatesTo{\context}{\type_1}{\type_2}$}
         \RightLabel{(\textsc{S-Computation})}
-        \UnaryInfC{$\translatesTo{\context}{\tComputation{\type_1}{\row}}{\tArrow{\tUnit}{\type_2}}$}
+        \UnaryInfC{$\translatesTo{\context}{\tComputation{\type_1}{\effect}}{\tArrow{\tUnit}{\type_2}}$}
         \DisplayProof
-          \AxiomC{$\hasKind{\context}{\row}{\kRow}$}
-        \RightLabel{(\textsc{S-Row})}
-        \UnaryInfC{$\translatesTo{\context}{\row}{\tUnit}$}
+          \AxiomC{$\hasKind{\context}{\effect}{\kEffect}$}
+        \RightLabel{(\textsc{S-Effect})}
+        \UnaryInfC{$\translatesTo{\context}{\effect}{\tUnit}$}
         \DisplayProof
       \end{center}
 

--- a/paper/macros.tex
+++ b/paper/macros.tex
@@ -28,16 +28,15 @@
 \newcommand\tForAll[3]{\forall \kAnno{#1}{#2} \; . \; #3}
 \newcommand\tForAllNoKind[2]{\forall #1 \; . \; #2}
 \newcommand\tComputation[2]{#1 \; ! \; #2}
-\newcommand\row{\varepsilon}
+\newcommand\effect{\varepsilon}
 \newcommand\tPure{\circ}
-\newcommand\tUnion[2]{#1, #2}
 \newcommand\tVoid{\mathbf{0}}
 \newcommand\tUnit{\mathbf{1}}
 
 % Kinds
 \newcommand\kind{\kappa}
 \newcommand\kType{\star}
-\newcommand\kRow{\diamond}
+\newcommand\kEffect{\diamond}
 \newcommand\kWitness[1]{\left\langle #1 \right\rangle}
 
 % Contexts


### PR DESCRIPTION
This PR deletes effect rows entirely, replacing them with "effects" which are just type variables and have no internal structure. There is no more "union" operator on effect rows, and we no longer need to deal with reordering, duplication, extension, row polymorphism, or any of that complexity. No more partial orders / equivalence relations either.

The system is now unprecedentedly simple, and I don't think it's possible for it to be any simpler!

In the examples below, note the following:

- ```haskell
  Monoid a => t
  ```

  is syntactic sugar for

  ```haskell
  forall (a : *) (i : <Monoid a>) . t
  ```
  Generalizing that,

  ```haskell
  (Num a, Monoid a) => t
  ```

  is syntactic sugar for

  ```haskell
  forall (a : *) (i : <Num a>) (j : <Monoid a>) . t
  ```
- All the type abstractions and applications have been left implicit, for type inference to fill in. For example, `reflect` is short for `reflect t` for some inferred type `t`. And `reify foo in bar` is short for `reify a <- foo in bar` where `a` is a fresh type variable.

## Type classes

For type classes, everything is the same as before.

```haskell
-- Define a type class as an ordinary data type.

data Monoid a = Monoid {
  mEmpty  : a,
  mAppend : a -> a -> a
}

-- Define methods for the type class.

mempty : Monoid a => a
mempty = mEmpty reflect

mappend : Monoid a => a -> a -> a
mappend = mAppend reflect

-- Define a polymorphic function using the methods.

square : Monoid a => a -> a
square x = mappend x x

-- Make an instance of the class and use it.

nine : Int
nine = reify Monoid 1 (*)
       in square 3
```

## Effect classes

Defining and using effect classes follows the same pattern as type classes, except they they additionally make use of the `t ! e` type constructor (where `t` is a type and `e` is an effect).

```haskell
-- Define an effect class as an ordinary data type.

data IO e = IO {
  ioGetLine   : String ! e,
  ioPrintLine : String -> () ! e
}

-- Define operations for the effect class.

getLine : IO e => String ! e
getLine = ioGetLine reflect

printLine : IO e => String -> () ! e
printLine = ioPrintLine reflect

-- Make a handler and use it.

computation : () ! ◦
computation =
  reify IO (pure "Foo") (\_ -> pure ())
  in do x <- getLine
     in printLine x

result : ()
result = run computation

-- Here's another effect class.

data Log e = Log {
  lLog : String -> () ! e
}

log : Log e => String -> () ! e
log = lLog reflect

-- Here's a computation that uses two effect classes.

computation : (Log e, IO e) => () ! e
computation = do
  log "What is your name?"
  name <- getLine
  printLine ("Hello, " ++ name ++ "!")

-- We can remove one of the effects by handling it.

computation' : IO e => () ! e
computation' = reify Log (_ -> pure ()) in computation

-- Suppose we have a third effect class:

data MyEffect e = MyEffect {
  mMyEffect : () ! e
}

myEffect : MyEffect e => () ! e
myEffect = mMyEffect reflect

-- We could also handle one of the two effect class in terms of another effect class.

computation'' : (IO e, MyEffect e) => () ! e
computation'' = reify Log (_ -> myEffect) in computation
```

@esdrw 