### PR TITLE
Fix how the parser handles type constructors

### DIFF
--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -104,8 +104,10 @@ TVar
   : x { UserTVarName $1 }
 
 TConst
-  : X                      { ($1, []) }
-  | TConst Type %prec HIGH { (fst $1, $2 : snd $1) }
+  : X %prec LOW         { ($1, []) }
+  | TConst TVar         { (fst $1, TVar $2 : snd $1) }
+  | TConst X            { (fst $1, (TConst (UserTConstName $2) []) : snd $1) }
+  | TConst '(' Type ')' { (fst $1, $3 : snd $1) }
 
 TVars
   : TVar          { [$1] }


### PR DESCRIPTION
Fix how the parser handles type constructors.

```haskell
⨠ 3 : List Int
  Error: Unable to unify Int with List Int
⨠ 3 : Foo A B C
  Error: Unable to unify Int with Foo A B C
⨠ 3 : Foo a b c
  Error: Unable to unify Int with Foo $0 $1 $2
⨠ 3 : Foo a (b -> c) d
  Error: Unable to unify Int with Foo $0 ($1 → $2) $3
⨠ 3 : Foo a b c -> Bar d e f
  Error: Unable to unify Int with Foo $0 $1 $2 → Bar $3 $4 $5
```

@esdrw 