### PR TITLE
Delete arrow types and represent them as type constructors

### DIFF
--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -6,10 +6,11 @@ import Lexer (Token(..))
 import Syntax
   ( EVarName(..)
   , ITerm(..)
-  , TConstName(..)
+  , TConName(..)
   , TVarName(..)
   , Type(..)
   , annotate
+  , arrowType
   , listType
   )
 
@@ -82,8 +83,8 @@ ITerm
 
 Type
   : x                     { TVar (UserTVarName $1) }
-  | TConst %prec LOW      { TConst (UserTConstName $ fst $1) (reverse $ snd $1) }
-  | Type '->' Type        { TArrow $1 $3 }
+  | TCon %prec LOW      { TCon (UserTConName $ fst $1) (reverse $ snd $1) }
+  | Type '->' Type        { arrowType $1 $3 }
   | forall TVars '.' Type { foldr (\x t -> TForAll x t) $4 (reverse $2) }
   | '(' Type ')'          { $2 }
 
@@ -103,11 +104,11 @@ EVars
 TVar
   : x { UserTVarName $1 }
 
-TConst
+TCon
   : X %prec LOW         { ($1, []) }
-  | TConst TVar         { (fst $1, TVar $2 : snd $1) }
-  | TConst X            { (fst $1, (TConst (UserTConstName $2) []) : snd $1) }
-  | TConst '(' Type ')' { (fst $1, $3 : snd $1) }
+  | TCon TVar         { (fst $1, TVar $2 : snd $1) }
+  | TCon X            { (fst $1, (TCon (UserTConName $2) []) : snd $1) }
+  | TCon '(' Type ')' { (fst $1, $3 : snd $1) }
 
 TVars
   : TVar          { [$1] }

--- a/implementation/src/Substitution.hs
+++ b/implementation/src/Substitution.hs
@@ -15,11 +15,11 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Syntax
   ( FTerm(..)
-  , FreeTConsts
+  , FreeTCons
   , FreeTVars
   , TVarName(..)
   , Type(..)
-  , freeTConsts
+  , freeTCons
   , freeTVars
   , subst
   )
@@ -34,10 +34,10 @@ instance FreeTVars Substitution where
   freeTVars (Substitution m) =
     nub $ Map.foldr (\t as -> freeTVars t ++ as) [] m
 
--- The free type constants of the codomain of a substitution
-instance FreeTConsts Substitution where
-  freeTConsts (Substitution m) =
-    nub $ Map.foldr (\t cs -> freeTConsts t ++ cs) [] m
+-- The free type constructors of the codomain of a substitution
+instance FreeTCons Substitution where
+  freeTCons (Substitution m) =
+    nub $ Map.foldr (\t cs -> freeTCons t ++ cs) [] m
 
 -- Check that a substitution is idempotent.
 idempotencyCheck :: Substitution -> Substitution


### PR DESCRIPTION
Delete arrow types and represent them as type constructors. Everything is the same to the user. I just removed some redundant logic by treating arrow types as just a special case of type constructors.

This PR only affects the Haskell implementation, not the paper.

@esdrw 