### PR TITLE
Remove operational semantics as a CCS concept

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -76,14 +76,9 @@
 \begin{CCSXML}
   <ccs2012>
     <concept>
-      <concept_id>10003752.10010124.10010125.10010130</concept_id>
-      <concept_desc>Theory of computation~Type structures</concept_desc>
+      <concept_id>10003752.10003790.10011740</concept_id>
+      <concept_desc>Theory of computation~Type theory</concept_desc>
       <concept_significance>500</concept_significance>
-    </concept>
-    <concept>
-      <concept_id>10003752.10010124.10010131.10010134</concept_id>
-      <concept_desc>Theory of computation~Operational semantics</concept_desc>
-      <concept_significance>300</concept_significance>
     </concept>
     <concept>
       <concept_id>10011007.10011006.10011008.10011009.10011012</concept_id>
@@ -93,8 +88,7 @@
   </ccs2012>
 \end{CCSXML}
 
-  \ccsdesc[500]{Theory of computation~Type structures}
-  \ccsdesc[300]{Theory of computation~Operational semantics}
+  \ccsdesc[500]{Theory of computation~Type theory}
   \ccsdesc[500]{Software and its engineering~Functional languages}
 
   \keywords{Type classes, effect classes, algebraic effects, effect handlers, reflection}


### PR DESCRIPTION
Remove operational semantics as a CCS concept since we don't have an operational semantics. 😛 

@esdrw 