### PR TITLE
Flip the order of state and exception in the TypeCheck monad transformer stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ lint-general:
 	    -path ./.paper-build -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o \( \
-	    -name '*.hs' -o \
 	    -name '*.rb' -o \
 	    -name '*.sh' -o \
 	    -name '*.v' -o \


### PR DESCRIPTION
Flip the order of state and exception in the TypeCheck monad transformer stack.

Reader, Writer, and State all commute with each other. But Exception and State do not. It makes more sense to have `ExceptT` on the inside (i.e., the whole type is wrapped in an `Either`) because when an exception happens we don't care about the state.

I switched to using the monad transformer version of the state monad (i.e., `StateT` instead of `State`) because it makes these kinds of refactors (changing the order of monad transformers) easier.

Unfortunately `hindent` does not want to split the long definition of the `TypeCheck` monad onto multiple lines. :( So I have disabled the line-length check (and the other checks that come with it) for Haskell files. I think this is okay because it doesn't make sense to check the formatting of auto-formatted files, though I just wish `hindent` would wrap the line.

@esdrw 