### PR TITLE
Replace the '*' kind with a 'type' keyword

### DIFF
--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -40,6 +40,7 @@ $idChar = [_ $lower $upper $digit]
 "if"           { tokenAtom TokenIf }
 "then"         { tokenAtom TokenThen }
 "true"         { tokenAtom TokenTrue }
+"type"         { tokenAtom TokenType }
 $digit+        { tokenInteger TokenIntLit }
 $white+        ;
 @idLower       { tokenString TokenIdLower }
@@ -73,6 +74,7 @@ data Token
   | TokenSlash
   | TokenThen
   | TokenTrue
+  | TokenType
   deriving Eq
 
 instance Show Token where
@@ -101,6 +103,7 @@ instance Show Token where
   show TokenSlash = "/"
   show TokenThen = "then"
   show TokenTrue = "true"
+  show TokenType = "type"
 
 alexScanAction :: Alex (Maybe Token)
 alexScanAction = do

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -48,6 +48,7 @@ import Syntax
   lambda { TokenLambda }
   then   { TokenThen }
   true   { TokenTrue }
+  type   { TokenType }
   x      { TokenIdLower $$ }
 
 %nonassoc LOW
@@ -59,7 +60,7 @@ import Syntax
 %left '+' '-'
 %left '*' '/'
 
-%nonassoc true false if i x lambda '(' '[' forall X
+%nonassoc true false if i x lambda '(' '[' forall type X
 
 %nonassoc HIGH
 
@@ -92,7 +93,7 @@ Type
   | '(' Type ')'          { $2 }
 
 Kind
-  : '*' { KType }
+  : type { KType }
 
 EListItems
   :                      { [] }

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -878,7 +878,7 @@ instance PrettyPrint Type where
 
 instance PrettyPrint Kind where
   prettyPrint (KVar b) = show b
-  prettyPrint KType = "*"
+  prettyPrint KType = "type"
 
 -- The first node is the current one. The second is the one to be embedded.
 embed :: (Prec a, PrettyPrint a) => Assoc -> a -> a -> String


### PR DESCRIPTION
Replace the `*` kind with a `type` keyword. This is purely a cosmetic change. I'm making this change so I can demo this to my team without needing to explain how `*` has two meanings.