### PR TITLE
Replace all uses of 'return' with 'pure'

### DIFF
--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -15,22 +15,22 @@ import System.Exit (exitFailure, exitSuccess)
 runProgram :: String -> IO Bool
 runProgram program =
   if all isSpace program
-    then return True
+    then pure True
     else do
       result <-
         runExceptT $ do
-          tokens <- ExceptT . return $ scan program
-          iterm <- ExceptT . return $ parse tokens
-          (fterm, ftype) <- ExceptT . return $ typeCheck iterm
-          rterm <- ExceptT . return $ eval fterm
+          tokens <- ExceptT . pure $ scan program
+          iterm <- ExceptT . pure $ parse tokens
+          (fterm, ftype) <- ExceptT . pure $ typeCheck iterm
+          rterm <- ExceptT . pure $ eval fterm
           lift . putStrLn $ "  ⇒ " ++ show rterm
           lift . putStrLn $ "  : " ++ show ftype
-          return ()
+          pure ()
       case result of
         Left s -> do
           putStrLn ("  Error: " ++ s)
-          return False
-        Right () -> return True
+          pure False
+        Right () -> pure True
 
 main :: IO ()
 main = do

--- a/implementation/src/Evaluation.hs
+++ b/implementation/src/Evaluation.hs
@@ -8,47 +8,47 @@ import Syntax (FTerm(..), subst)
 
 eval :: FTerm -> Either String FTerm
 eval (FEVar x) = throwError $ "Unbound variable: " ++ show x
-eval (FEAbs x t e) = return $ FEAbs x t e
+eval (FEAbs x t e) = pure $ FEAbs x t e
 eval (FEApp e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case e3 of
     FEAbs x _ e5 -> eval $ subst x e4 e5
     _ -> throwError $ "Cannot apply " ++ show e3 ++ " to " ++ show e4
-eval (FETAbs a k e) = return $ FETAbs a k e
+eval (FETAbs a k e) = pure $ FETAbs a k e
 eval (FETApp e1 t) = do
   e2 <- eval e1
   case e2 of
     FETAbs a _ e3 -> eval $ subst a t e3
     _ -> throwError $ "Cannot apply " ++ show e2 ++ " to " ++ show t
-eval FETrue = return FETrue
-eval FEFalse = return FEFalse
+eval FETrue = pure FETrue
+eval FEFalse = pure FEFalse
 eval (FEIf e1 e2 e3) = do
   e4 <- eval e1
   e5 <- eval e2
   e6 <- eval e3
   case e4 of
-    FETrue -> return e5
-    FEFalse -> return e6
+    FETrue -> pure e5
+    FEFalse -> pure e6
     _ -> throwError $ show e4 ++ " is not a Boolean"
-eval (FEIntLit i) = return $ FEIntLit i
+eval (FEIntLit i) = pure $ FEIntLit i
 eval (FEAdd e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case (e3, e4) of
-    (FEIntLit i1, FEIntLit i2) -> return $ FEIntLit (i1 + i2)
+    (FEIntLit i1, FEIntLit i2) -> pure $ FEIntLit (i1 + i2)
     _ -> throwError $ "Cannot add " ++ show e3 ++ " and " ++ show e4
 eval (FESub e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case (e3, e4) of
-    (FEIntLit i1, FEIntLit i2) -> return $ FEIntLit (i1 - i2)
+    (FEIntLit i1, FEIntLit i2) -> pure $ FEIntLit (i1 - i2)
     _ -> throwError $ "Cannot subtract " ++ show e4 ++ " from " ++ show e3
 eval (FEMul e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case (e3, e4) of
-    (FEIntLit i1, FEIntLit i2) -> return $ FEIntLit (i1 * i2)
+    (FEIntLit i1, FEIntLit i2) -> pure $ FEIntLit (i1 * i2)
     _ -> throwError $ "Cannot multiply " ++ show e3 ++ " and " ++ show e4
 eval (FEDiv e1 e2) = do
   e3 <- eval e1
@@ -57,20 +57,20 @@ eval (FEDiv e1 e2) = do
     (FEIntLit i1, FEIntLit i2) ->
       if i2 == 0
         then throwError $ "Cannot divide " ++ show i1 ++ " by 0"
-        else return $ FEIntLit (i1 `div` i2)
+        else pure $ FEIntLit (i1 `div` i2)
     _ -> throwError $ "Cannot divide " ++ show e3 ++ " by " ++ show e4
 eval (FEList es1) = do
   es2 <-
     foldM
       (\es2 e1 -> do
          e2 <- eval e1
-         return $ e2 : es2)
+         pure $ e2 : es2)
       []
       es1
-  return $ FEList $ reverse es2
+  pure $ FEList $ reverse es2
 eval (FEConcat e1 e2) = do
   e3 <- eval e1
   e4 <- eval e2
   case (e3, e4) of
-    (FEList es1, FEList es2) -> return $ FEList (es1 ++ es2)
+    (FEList es1, FEList es2) -> pure $ FEList (es1 ++ es2)
     _ -> throwError $ "Cannot concatenate " ++ show e3 ++ " and " ++ show e4

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -123,13 +123,13 @@ scan :: String -> Either String [Token]
 scan s = fmap reverse $ runAlex s $ do
   let loop memo = do r <- alexScanAction
                      case r of
-                       Nothing -> return memo
+                       Nothing -> pure memo
                        Just t -> do rest <- loop (t : memo)
-                                    return rest
+                                    pure rest
   loop []
 
 alexEOF :: Alex (Maybe Token)
-alexEOF = return Nothing
+alexEOF = pure Nothing
 
 tokenAtom :: Token -> AlexAction (Maybe Token)
 tokenAtom t = token (\_ _ -> Just t)


### PR DESCRIPTION
Replace all uses of `return` with `pure` (why depend on `Monad` when `Applicative` will do the trick).