### PR TITLE
Put GHC options and extensions in `package.yml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ clean-formalization:
 implementation:
 	(cd implementation && \
 	  set -o pipefail && \
-	  stack build --pedantic --install-ghc --allow-different-user 2>&1 | \
+	  stack build --install-ghc --allow-different-user 2>&1 | \
 	    tee ../build-log.txt) || \
 	  (rm -f build-log.txt && false) || \
 	  exit 1
@@ -135,7 +135,7 @@ implementation:
 
 test-implementation: implementation
 	cd implementation && \
-	  stack test --pedantic --install-ghc --allow-different-user && \
+	  stack test --install-ghc --allow-different-user && \
 	  stack exec implementation-exe examples/bools.g && \
 	  stack exec implementation-exe examples/church.g && \
 	  stack exec implementation-exe examples/ints.g && \

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -3,7 +3,7 @@
 First, make sure the dependencies listed below are installed. Then you can build the demo with:
 
 ```sh
-stack build --pedantic --install-ghc --allow-different-user
+stack build --install-ghc --allow-different-user
 ```
 
 Use either of the following to run the demo:

--- a/implementation/package.yaml
+++ b/implementation/package.yaml
@@ -16,6 +16,15 @@ description: >
 dependencies:
 - base >= 4.7 && < 5
 
+ghc-options:
+- -Wall
+- -Werror
+
+default-extensions:
+- FlexibleInstances
+- FunctionalDependencies
+- MultiParamTypeClasses
+
 library:
   source-dirs: src
   dependencies:

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 -- The algorithm presented here is based on the paper by Daan Leijen called
 -- "HMF: Simple type inference for first-class polymorphism". That paper was
 -- published in The 13th ACM SIGPLAN International Conference on Functional

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -1,5 +1,8 @@
 {
 
+-- Alex generates code that does not pass the unused imports check, but we
+-- compile it with `-Wall -Werror`. The following pragma downgrades that
+-- check from an error to a warning for this file to make GHC happy.
 {-# OPTIONS_GHC -Wwarn=unused-imports #-}
 
 module Lexer (Token(..), scan) where

--- a/implementation/src/Substitution.hs
+++ b/implementation/src/Substitution.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FunctionalDependencies #-}
-
 module Substitution
   ( ApplySubst
   , Substitution

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 module Syntax
   ( BBigLambda(..)
   , BForAll(..)


### PR DESCRIPTION
This PR implements three improvements:

- Instead of passing the `--pedantic` flag to `stack build`, we put the corresponding `ghc-options` in `package.yml`. Now anyone can run `stack build` with no extra flags and get consistent results.
- We also move all language extensions to `package.yml`. Going forward, this will allow us to add extensions like `OverloadedStrings` that we want to apply globally. We maintain that it is better to have a consistent set of language extensions everywhere rather than have each file declare which extensions it relies on. That way it feels like each file is written in the same language.
- We add a comment to explain the mysterious `{-# OPTIONS_GHC -Wwarn=unused-imports #-}` line in `Lexer.x`.