### PR TITLE
Fix a typo in the Church Booleans example

### DIFF
--- a/implementation/examples/bools.g
+++ b/implementation/examples/bools.g
@@ -2,5 +2,5 @@
 three = if true then 3 else 4;
 
 # Type inference gives this type for the following function:
-#   ∀α . Bool → α → α → α
+#   ∀(α : Type) . Bool → α → α → α
 \x y z -> if x then y else z

--- a/implementation/examples/church.g
+++ b/implementation/examples/church.g
@@ -4,21 +4,21 @@ pair = \x y f -> f x y
      : forall a b c .
        a -> b -> (a -> b -> c) -> c;
 first = p -> p (\x y -> x)
-     : forall a b .
-       (forall c . (a -> b -> c) -> c) ->
-       a;
+      : forall a b .
+        (forall c . (a -> b -> c) -> c) ->
+        a;
 second = p -> p (\x y -> y)
-     : forall a b .
-       (forall c . (a -> b -> c) -> c) ->
-       b;
+       : forall a b .
+         (forall c . (a -> b -> c) -> c) ->
+         b;
 
 # A Boolean can be represented by a function which takes two arguments and
 # returns one of them. We use 'yes' and 'no' here because 'true' and 'false'
 # are native Booleans.
 yes = \x y -> x
     : forall a . a -> a -> a;
-no = \x y -> x
-    : forall a . a -> a -> a;
+no = \x y -> y
+   : forall a . a -> a -> a;
 not = \b x y -> b y x
     : forall a .
       (forall b . b -> b -> b) ->
@@ -34,28 +34,28 @@ succ = \n f x -> f (n f x)
        (forall b . (b -> b) -> b -> b) ->
        (a -> a) -> a -> a;
 add = \m n f x -> m f (n f x)
-     : forall a .
-       (forall b . (b -> b) -> b -> b) ->
-       (forall b . (b -> b) -> b -> b) ->
-        (a -> a) -> a -> a;
+    : forall a .
+      (forall b . (b -> b) -> b -> b) ->
+      (forall b . (b -> b) -> b -> b) ->
+      (a -> a) -> a -> a;
 mul = \m n f -> m (n f)
-     : forall a .
-       (forall b . (b -> b) -> b -> b) ->
-       (forall b . (b -> b) -> b -> b) ->
-        (a -> a) -> a -> a;
+    : forall a .
+      (forall b . (b -> b) -> b -> b) ->
+      (forall b . (b -> b) -> b -> b) ->
+      (a -> a) -> a -> a;
 exp = \m n -> n m
-     : forall a .
-       (forall b . (b -> b) -> b -> b) ->
-       (forall b . (b -> b) -> b -> b) ->
-        (a -> a) -> a -> a;
+    : forall a .
+      (forall b . (b -> b) -> b -> b) ->
+      (forall b . (b -> b) -> b -> b) ->
+      (a -> a) -> a -> a;
 
 # A list can be represented by its fold function (foldr in this example).
 nil = \f i -> i
-    : forall a b. (a -> b -> b) -> b -> b;
+    : forall a b . (a -> b -> b) -> b -> b;
 cons = \x l f i -> f x (l f i)
      : forall a b .
        a ->
-       (forall c. (a -> c -> c) -> c -> c) ->
+       (forall c . (a -> c -> c) -> c -> c) ->
        (a -> b -> b) ->
        b ->
        b;
@@ -66,7 +66,7 @@ toInt = n -> n (x -> x + 1) 0
 
 # This function converts a Church list into a native list.
 toList = l -> l (\x y -> [x] ++ y) []
-       : forall a . (forall b. (a -> b -> b) -> b -> b) -> List a;
+       : forall a . (forall b . (a -> b -> b) -> b -> b) -> List a;
 
 # 3 ^ 4 = 81
 three = succ (succ (succ zero)) : (forall a . (a -> a) -> a -> a);

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -869,7 +869,7 @@ instance PrettyPrint Type where
 
 instance PrettyPrint Kind where
   prettyPrint (KVar b) = show b
-  prettyPrint KType = "type"
+  prettyPrint KType = "Type"
 
 -- The first node is the current one. The second is the one to be embedded.
 embed :: (Prec a, PrettyPrint a) => Assoc -> a -> a -> String


### PR DESCRIPTION
Fix a typo in the Church Booleans example. I could have given this a more specific type (`forall a b . a -> b -> b`) such that correctness follows from parametricity as a free theorem, but then `yes` and `no` would have differing types (which feels weird).

I also made a few stylistic changes.