### PR TITLE
Rename the Docker repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ run-implementation: implementation
 docker-deps:
 	docker build \
 	  -f scripts/Dockerfile \
-	  -t stephanmisc/effect-classes:deps \
+	  -t stephanmisc/paper:deps \
 	  .
 
 docker-build:
@@ -198,7 +198,7 @@ docker-build:
 	    --env "TRAVIS_REPO_SLUG=$$TRAVIS_REPO_SLUG" \
 	    --rm \
 	    --user=root \
-	    stephanmisc/effect-classes:deps \
+	    stephanmisc/paper:deps \
 	    bash -c ' \
 	      chown -R user:user repo && \
 	      cd repo && \


### PR DESCRIPTION
Rename the Docker repository from `effect-classes` to `paper`. This matches the S3 path where artifacts are uploaded to, and not having the name of the paper in the image tag will allow me to rename the paper more easily.