### PR TITLE
Turn on more GHC warnings

### DIFF
--- a/implementation/package.yaml
+++ b/implementation/package.yaml
@@ -18,7 +18,11 @@ dependencies:
 
 ghc-options:
 - -Wall
+- -Wcompat
 - -Werror
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
 
 default-extensions:
 - FlexibleInstances

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -387,11 +387,15 @@ instance Infer ITerm FTerm Type where
   infer (IEApp e1 e2) = do
     a1 <- freshTVar KType
     a2 <- freshTVar KType
-    (e3, TCon _ [t1, t2]) <- check e1 $ arrowType (TVar a1) (TVar a2)
-    (e4, _) <- check e2 t1
-    e5 <- runSubst e3
-    t4 <- runSubst t2
-    generalize (FEApp e5 e4) t4
+    e1Type <- check e1 $ arrowType (TVar a1) (TVar a2)
+    let (e4, t3, t4) =
+          case e1Type of
+            (e3, TCon _ [t1, t2]) -> (e3, t1, t2)
+            _ -> error "Something went wrong."
+    (e5, _) <- check e2 t3
+    e6 <- runSubst e4
+    t5 <- runSubst t4
+    generalize (FEApp e6 e5) t5
   infer (IELet x e1 e2) = do
     (e3, t1) <- infer e1
     withUserEVar x t1 $ do

--- a/implementation/src/Lexer.x
+++ b/implementation/src/Lexer.x
@@ -5,6 +5,11 @@
 -- check from an error to a warning for this file to make GHC happy.
 {-# OPTIONS_GHC -Wwarn=unused-imports #-}
 
+-- Alex generates code that does not pass this incomplete pattern match check.
+-- The following pragma downgrades that check from an error to a warning for
+-- this file to make GHC happy.
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
+
 module Lexer (Token(..), scan) where
 
 }


### PR DESCRIPTION
Turn on more GHC warnings.

These were recommended by
https://lexi-lambda.github.io/blog/2018/02/10/an-opinionated-guide-to-haskell-in-2018/.